### PR TITLE
fix: remove `golangci-lint` config only needed by `libevm`

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -30,22 +30,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0 # Required for go-header check https://github.com/golangci/golangci-lint/issues/2470#issuecomment-1473658471
       - uses: actions/setup-go@v5
         with:
           go-version-file: "go.mod"
-      - name: goheader
-        if: ${{ github.event_name == 'pull_request' }}
-        # The goheader linter is only enabled in the CI so that it runs only on modified or new files
-        # (see only-new-issues: true). It is disabled in .golangci.yml because
-        # golangci-lint running locally is not aware of new/modified files compared to the base
-        # commit of a pull request, and we want to avoid reporting invalid goheader errors.
-        uses: golangci/golangci-lint-action@v6
-        with:
-          version: v1.60
-          only-new-issues: true
-          args: --enable-only goheader
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v6
         with:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -16,9 +16,7 @@ linters:
     - gci
     - gocheckcompilerdirectives
     - gofmt
-    # goheader is disabled but it is enabled in the CI with a flag.
-    # Please see .github/workflows/golangci-lint.yml which explains why.
-    # - goheader
+    - goheader
     - goimports
     - gomodguard
     - gosec
@@ -78,38 +76,6 @@ linters-settings:
         disabled: true
 
 issues:
-  exclude-dirs-use-default: false
-  exclude-rules:
-    - path-except: libevm
-      linters:
-        # If any issue is flagged in a non-libevm file, add the linter here
-        # because the problem isn't under our control.
-        - containedctx
-        - forcetypeassert
-        - errcheck
-        - gci
-        - gofmt
-        - goheader
-        - goimports
-        - gosec
-        - gosimple
-        - govet
-        - nakedret
-        - nestif
-        - nilerr
-        - nolintlint
-        - revive
-        - staticcheck
-        - tagliatelle
-        - testableexamples
-        - testifylint
-        - thelper
-        - tparallel
-        - typecheck
-        - usestdlibvars
-        - varnamelen
-        - wastedassign
-        - whitespace
   include:
     # Many of the default exclusions are because, verbatim "Annoying issue",
     # which defeats the point of a linter.


### PR DESCRIPTION
`goheader` only checks new issues in `libevm` because `MOD-YEAR-RANGE` breaks otherwise (we can reintroduce this next year if we haven't moved the code into `avalanchego` yet). The other deleted config is what `libevm` uses to avoid linting `geth` code.

Go workflows are still expected to fail, as described in #3, and all that matters is that they run (and `golangci-lint` _attempts_ to lint but finds no files).