### PR TITLE
feat: `intmath` package

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module github.com/ava-labs/strevm
 
 go 1.23.7
+
+require golang.org/x/exp v0.0.0-20250620022241-b7579e27df2b

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+golang.org/x/exp v0.0.0-20250620022241-b7579e27df2b h1:M2rDM6z3Fhozi9O7NWsxAkg/yqS/lQJ6PmkyIV3YP+o=
+golang.org/x/exp v0.0.0-20250620022241-b7579e27df2b/go.mod h1:3//PLf8L/X+8b4vuAfHzxeRUl04Adcb341+IGKfnqS8=

--- a/intmath/intmath.go
+++ b/intmath/intmath.go
@@ -40,6 +40,10 @@ func MulDiv[T ~uint64](a, b, den T) (quo, rem T, err error) {
 // CeilDiv returns `ceil(num/den)`, i.e. the rounded-up quotient.
 func CeilDiv[T ~uint64](num, den T) T {
 	lo, hi := bits.Add64(uint64(num), uint64(den)-1, 0)
+	// [bits.Div64] panics if the denominator is zero (expected behaviour) or if
+	// `den <= hi`. The latter is impossible because `hi` is a carry bit (i.e.
+	// can only be 0 or 1) and even if `num==MaxUint64` then `den` would have to
+	// be `>=2` for `hi` to be non-zero.
 	quo, _ := bits.Div64(hi, lo, uint64(den))
 	return T(quo)
 }

--- a/intmath/intmath.go
+++ b/intmath/intmath.go
@@ -1,0 +1,37 @@
+// Copyright (C) 2025, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE for licensing terms.
+
+// Package intmath provides special-case integer arithmetic.
+package intmath
+
+import (
+	"math/bits"
+
+	"golang.org/x/exp/constraints"
+)
+
+// BoundedSubtract returns `max(a-b,floor)` without underflow.
+func BoundedSubtract[T constraints.Unsigned](a, b, floor T) T {
+	// If `floor + b` overflows then it's impossible for `a` to ever be large
+	// enough for the subtraction to not be bounded.
+	minA := floor + b
+	if overflow := minA < b; overflow || a <= minA {
+		return floor
+	}
+	return a - b
+}
+
+// MulDiv returns the quotient and remainder of `(a*b)/den` without overflow in
+// the event that `a*b>=2^64`.
+func MulDiv[T ~uint64](a, b, den T) (quo, rem T) {
+	hi, lo := bits.Mul64(uint64(a), uint64(b))
+	q, r := bits.Div64(hi, lo, uint64(den))
+	return T(q), T(r)
+}
+
+// CeilDiv returns `ceil(num/den)`, i.e. the rounded-up quotient.
+func CeilDiv[T ~uint64](num, den T) T {
+	lo, hi := bits.Add64(uint64(num), uint64(den)-1, 0)
+	quo, _ := bits.Div64(hi, lo, uint64(den))
+	return T(quo)
+}

--- a/intmath/intmath_test.go
+++ b/intmath/intmath_test.go
@@ -4,6 +4,7 @@
 package intmath
 
 import (
+	"errors"
 	"math"
 	"math/rand/v2"
 	"testing"
@@ -50,9 +51,13 @@ func TestMulDiv(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		if gotQuo, gotRem := MulDiv(tt.a, tt.b, tt.div); gotQuo != tt.wantQuo || gotRem != tt.wantRem {
-			t.Errorf("MulDiv[%T](%[1]d, %d, %d) got (%d, %d); want (%d, %d)", tt.a, tt.b, tt.div, gotQuo, gotRem, tt.wantQuo, tt.wantRem)
+		if gotQuo, gotRem, err := MulDiv(tt.a, tt.b, tt.div); err != nil || gotQuo != tt.wantQuo || gotRem != tt.wantRem {
+			t.Errorf("MulDiv[%T](%[1]d, %d, %d) got (%d, %d, %v); want (%d, %d, nil)", tt.a, tt.b, tt.div, gotQuo, gotRem, err, tt.wantQuo, tt.wantRem)
 		}
+	}
+
+	if _, _, err := MulDiv[uint64](max, 2, 1); !errors.Is(err, ErrOverflow) {
+		t.Errorf("MulDiv[uint64]([max uint64], 2, 1) got error %v; want %v", err, ErrOverflow)
 	}
 }
 

--- a/intmath/intmath_test.go
+++ b/intmath/intmath_test.go
@@ -37,16 +37,16 @@ func TestMulDiv(t *testing.T) {
 		a, b, div, wantQuo, wantRem uint64
 	}{
 		{
-			5, 2, 3, // 10/3
-			3, 1,
+			a: 5, b: 2, div: 3, // 10/3
+			wantQuo: 3, wantRem: 1,
 		},
 		{
-			5, 3, 3, // 15/3
-			5, 0,
+			a: 5, b: 3, div: 3, // 15/3
+			wantQuo: 5, wantRem: 0,
 		},
 		{
-			max, 4, 8, // must avoid overflow
-			max / 2, 4,
+			a: max, b: 4, div: 8, // must avoid overflow
+			wantQuo: max / 2, wantRem: 4,
 		},
 	}
 
@@ -67,11 +67,11 @@ func TestCeilDiv(t *testing.T) {
 	}
 
 	tests := []test{
-		{4, 2, 2},
-		{4, 1, 4},
-		{4, 3, 2},
-		{10, 3, 4},
-		{max, 2, 1 << 63}, // must not overflow
+		{num: 4, den: 2, want: 2},
+		{num: 4, den: 1, want: 4},
+		{num: 4, den: 3, want: 2},
+		{num: 10, den: 3, want: 4},
+		{num: max, den: 2, want: 1 << 63}, // must not overflow
 	}
 
 	rng := rand.New(rand.NewPCG(0, 0)) //nolint:gosec // Reproducibility is valuable for tests
@@ -80,13 +80,13 @@ func TestCeilDiv(t *testing.T) {
 		r := uint64(rng.Uint32())
 
 		tests = append(tests, []test{
-			{l*r + 1, l, r + 1},
-			{l*r + 0, l, r},
-			{l*r - 1, l, r},
+			{num: l*r + 1, den: l, want: r + 1},
+			{num: l*r + 0, den: l, want: r},
+			{num: l*r - 1, den: l, want: r},
 			// l <-> r
-			{l*r + 1, r, l + 1},
-			{l*r + 0, r, l},
-			{l*r - 1, r, l},
+			{num: l*r + 1, den: r, want: l + 1},
+			{num: l*r + 0, den: r, want: l},
+			{num: l*r - 1, den: r, want: l},
 		}...)
 	}
 

--- a/intmath/intmath_test.go
+++ b/intmath/intmath_test.go
@@ -16,13 +16,13 @@ func TestBoundedSubtract(t *testing.T) {
 	tests := []struct {
 		a, b, floor, want uint64
 	}{
-		{1, 2, 0, 0}, // a < b
-		{2, 1, 0, 1}, // not bounded
-		{2, 1, 1, 1}, // a - b == floor
-		{2, 2, 1, 1}, // bounded
-		{3, 1, 1, 2},
-		{max, 10, max - 9, max - 9}, // `a` threshold (`max+1`) would overflow uint64
-		{max, 10, max - 11, max - 10},
+		{a: 1, b: 2, floor: 0, want: 0}, // a < b
+		{a: 2, b: 1, floor: 0, want: 1}, // not bounded
+		{a: 2, b: 1, floor: 1, want: 1}, // a - b == floor
+		{a: 2, b: 2, floor: 1, want: 1}, // bounded
+		{a: 3, b: 1, floor: 1, want: 2},
+		{a: max, b: 10, floor: max - 9, want: max - 9}, // `a` threshold (`max+1`) would overflow uint64
+		{a: max, b: 10, floor: max - 11, want: max - 10},
 	}
 
 	for _, tt := range tests {

--- a/intmath/intmath_test.go
+++ b/intmath/intmath_test.go
@@ -1,0 +1,93 @@
+// Copyright (C) 2025, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE for licensing terms.
+
+package intmath
+
+import (
+	"math"
+	"math/rand/v2"
+	"testing"
+)
+
+const max = math.MaxUint64
+
+func TestBoundedSubtract(t *testing.T) {
+	tests := []struct {
+		a, b, floor, want uint64
+	}{
+		{1, 2, 0, 0}, // a < b
+		{2, 1, 0, 1}, // not bounded
+		{2, 1, 1, 1}, // a - b == floor
+		{2, 2, 1, 1}, // bounded
+		{3, 1, 1, 2},
+		{max, 10, max - 9, max - 9}, // `a` threshold (`max+1`) would overflow uint64
+		{max, 10, max - 11, max - 10},
+	}
+
+	for _, tt := range tests {
+		if got := BoundedSubtract(tt.a, tt.b, tt.floor); got != tt.want {
+			t.Errorf("BoundedSubtract[%T](%[1]d, %d, %d) got %d; want %d", tt.a, tt.b, tt.floor, got, tt.want)
+		}
+	}
+}
+
+func TestMulDiv(t *testing.T) {
+	tests := []struct {
+		a, b, div, wantQuo, wantRem uint64
+	}{
+		{
+			5, 2, 3, // 10/3
+			3, 1,
+		},
+		{
+			5, 3, 3, // 15/3
+			5, 0,
+		},
+		{
+			max, 4, 8, // must avoid overflow
+			max / 2, 4,
+		},
+	}
+
+	for _, tt := range tests {
+		if gotQuo, gotRem := MulDiv(tt.a, tt.b, tt.div); gotQuo != tt.wantQuo || gotRem != tt.wantRem {
+			t.Errorf("MulDiv[%T](%[1]d, %d, %d) got (%d, %d); want (%d, %d)", tt.a, tt.b, tt.div, gotQuo, gotRem, tt.wantQuo, tt.wantRem)
+		}
+	}
+}
+
+func TestCeilDiv(t *testing.T) {
+	type test struct {
+		num, den, want uint64
+	}
+
+	tests := []test{
+		{4, 2, 2},
+		{4, 1, 4},
+		{4, 3, 2},
+		{10, 3, 4},
+		{max, 2, 1 << 63}, // must not overflow
+	}
+
+	rng := rand.New(rand.NewPCG(0, 0)) //nolint:gosec // Reproducibility is valuable for tests
+	for range 50 {
+		l := uint64(rng.Uint32())
+		r := uint64(rng.Uint32())
+
+		tests = append(tests, []test{
+			{l*r + 1, l, r + 1},
+			{l*r + 0, l, r},
+			{l*r - 1, l, r},
+			// l <-> r
+			{l*r + 1, r, l + 1},
+			{l*r + 0, r, l},
+			{l*r - 1, r, l},
+		}...)
+	}
+
+	for _, tt := range tests {
+		if got := CeilDiv(tt.num, tt.den); got != tt.want {
+			t.Errorf("CeilDiv[%T](%[1]d, %d) got %d; want %d", tt.num, tt.den, got, tt.want)
+		}
+	}
+}


### PR DESCRIPTION
Useful abstractions for later code:

1. `BoundedSubtract(a, b, floor)` returns `max(a-b, floor)` without underflow.
2. `MulDiv(a, b, denominator)` returns `(a*b)/denominator` without overflow.
3. `CeilDiv(num, denom)` returns `num/denom` rounded _up_.