### PR TITLE
fix: `golangci-lint` enforces comments on exported identifiers

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -74,6 +74,15 @@ linters-settings:
         # Method parameters may be required by interfaces and forcing them to be
         # named _ is of questionable benefit.
         disabled: true
+      - name: exported
+        severity: error
+        disabled: false
+        exclude: [""]
+        arguments:
+          - "sayRepetitiveInsteadOfStutters"
+      - name: package-comments
+        severity: warning
+        disabled: false
 
 issues:
   include:


### PR DESCRIPTION
As it says on the tin.

Failing CI expected, as described in #3.