### PR TITLE
ci: fuzz all the things

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -72,7 +72,7 @@ jobs:
           echo "targets=$(grep --recursive --include '**_test.go' -oP "^func \KFuzz[^(]+" | xargs jq -c -n '$ARGS.positional' --args)" >> $GITHUB_OUTPUT
 
   go_fuzz:
-    needs: [ find_fuzz_targets ]
+    needs: [find_fuzz_targets]
     runs-on: ubuntu-latest
     strategy:
       matrix:


### PR DESCRIPTION
Adds a required CI job `go_fuzz`, which runs on a matrix strategy fed by another job that finds all Go fuzz targets. When on `main` (e.g. after merging a PR) the `-fuzztime` is 15 minutes, otherwise (e.g. an open PR) it is 60 seconds. This pattern results in parallel fuzzing of all targets.