### PR TITLE
Add `BuildBlock` and `BlockRebuilderFrom` hooks

### DIFF
--- a/hook/hook.go
+++ b/hook/hook.go
@@ -24,7 +24,19 @@ import (
 )
 
 // Points define user-injected hook points.
+//
+// Directly using this interface as a [BlockBuilder] is indicative of this node
+// locally building a block. Calling [Points.BlockRebuilderFrom] with an
+// existing block is indicative of this node reconstructing a block built
+// elsewhere during verification.
 type Points interface {
+	BlockBuilder
+	// BlockRebuilderFrom returns a [BlockBuilder] that will attempt to
+	// reconstruct the provided block. If the provided block is valid for
+	// inclusion, then the returned builder MUST be able to reconstruct an
+	// identical block.
+	BlockRebuilderFrom(block *types.Block) BlockBuilder
+
 	// GasTargetAfter returns the gas target that should go into effect
 	// immediately after the provided block.
 	GasTargetAfter(*types.Header) gas.Gas
@@ -43,6 +55,18 @@ type Points interface {
 	BeforeExecutingBlock(params.Rules, *state.StateDB, *types.Block) error
 	// AfterExecutingBlock is called immediately after executing the block.
 	AfterExecutingBlock(*state.StateDB, *types.Block, types.Receipts)
+}
+
+// BlockBuilder constructs a block given its components.
+type BlockBuilder interface {
+	// BuildBlock constructs a block with the given components. This method MUST
+	// be used rather than [types.NewBlock] to ensure any libevm block extras
+	// are properly populated.
+	BuildBlock(
+		header *types.Header,
+		txs []*types.Transaction,
+		receipts []*types.Receipt,
+	) *types.Block
 }
 
 // Op is an operation that can be applied to state during the execution of a

--- a/hook/hookstest/stub.go
+++ b/hook/hookstest/stub.go
@@ -11,6 +11,7 @@ import (
 	"github.com/ava-labs/libevm/params"
 
 	"github.com/ava-labs/strevm/hook"
+	"github.com/ava-labs/strevm/saetest"
 )
 
 // Stub implements [hook.Points].
@@ -21,6 +22,20 @@ type Stub struct {
 }
 
 var _ hook.Points = (*Stub)(nil)
+
+// BuildBlock calls [types.NewBlock] with its arguments.
+func (*Stub) BuildBlock(
+	header *types.Header,
+	txs []*types.Transaction,
+	receipts []*types.Receipt,
+) *types.Block {
+	return types.NewBlock(header, txs, nil, receipts, saetest.TrieHasher())
+}
+
+// BlockRebuilderFrom ignores its argument and returns itself.
+func (s *Stub) BlockRebuilderFrom(*types.Block) hook.BlockBuilder {
+	return s
+}
 
 // GasTargetAfter ignores its argument and always returns [Stub.Target].
 func (s *Stub) GasTargetAfter(*types.Header) gas.Gas {

--- a/sae/sae.go
+++ b/sae/sae.go
@@ -14,14 +14,8 @@ import (
 	"sync"
 	"time"
 
-	"github.com/ava-labs/libevm/core/types"
-	"github.com/ava-labs/libevm/trie"
 	"github.com/holiman/uint256"
 )
-
-func trieHasher() types.TrieHasher {
-	return trie.NewStackTrie(nil)
-}
 
 func unix(t time.Time) uint64 {
 	return uint64(t.Unix()) //nolint:gosec // Guaranteed to be positive


### PR DESCRIPTION
This PR provides the minimal hooks for allowing block creation within the hooks. The `BuildBlock` function on the `BlockBuilder` interface will be expanded to take in more arguments in the future. This PR is intended to mainly introduce the shape of the block building hooks.