### PR TITLE
Remove references to non-existent function

### DIFF
--- a/blocks/block.go
+++ b/blocks/block.go
@@ -37,8 +37,7 @@ type Block struct {
 	// Only the genesis block or the last pre-SAE block is synchronous. These
 	// are self-settling by definition so their `ancestry` MUST be nil.
 	synchronous bool
-	// Non-nil i.f.f. [Block.MarkExecuted] or [Block.ResotrePostExecutionState]
-	// have returned without error.
+	// Non-nil i.f.f. [Block.MarkExecuted] has returned without error.
 	execution atomic.Pointer[executionResults]
 
 	// Allows this block to be ruled out as able to be settled at a particular

--- a/blocks/execution.go
+++ b/blocks/execution.go
@@ -58,8 +58,7 @@ type executionResults struct {
 // true and [Block.WaitUntilExecuted] returning cleanly are both therefore
 // indicative of a successful database write by MarkExecuted.
 //
-// This method MUST NOT be called more than once and its usage is mutually
-// exclusive of [Block.RestorePostExecutionState]. The wall-clock [time.Time] is
+// This method MUST NOT be called more than once. The wall-clock [time.Time] is
 // for metrics only.
 func (b *Block) MarkExecuted(db ethdb.Database, byGas *gastime.Time, byWall time.Time, baseFee *big.Int, receipts types.Receipts, stateRootPost common.Hash) error {
 	e := &executionResults{


### PR DESCRIPTION
`Block.RestorePostExecutionState` doesn't exist (and neither does `Block.ResotrePostExecutionState`)