### PR TITLE
feat(sae): support and `eth_getUncleCountByBlockBy*` APIs

### DIFF
--- a/sae/rpc.go
+++ b/sae/rpc.go
@@ -204,16 +204,6 @@ func (b *ethAPIBackend) GetTransaction(ctx context.Context, txHash common.Hash) 
 	return true, tx, blockHash, blockNumber, index, nil
 }
 
-func (b *ethAPIBackend) GetBody(ctx context.Context, hash common.Hash, number rpc.BlockNumber) (*types.Body, error) {
-	if number < 0 || hash == (common.Hash{}) {
-		return nil, errors.New("invalid arguments; expect hash and no special block numbers")
-	}
-	if block, ok := b.vm.blocks.Load(hash); ok {
-		return block.EthBlock().Body(), nil
-	}
-	return rawdb.ReadBody(b.vm.db, hash, uint64(number)), nil
-}
-
 type canonicalReader[T any] func(ethdb.Reader, common.Hash, uint64) *T
 
 func readByNumber[T any](b *ethAPIBackend, n rpc.BlockNumber, read canonicalReader[T]) (*T, error) {

--- a/sae/rpc_test.go
+++ b/sae/rpc_test.go
@@ -227,6 +227,7 @@ func testGetByHash(ctx context.Context, t *testing.T, sut *SUT, want *types.Bloc
 	testRPCGetter(ctx, t, "BlockByHash", sut.BlockByHash, want.Hash(), want)
 	testRPCGetter(ctx, t, "HeaderByHash", sut.HeaderByHash, want.Hash(), want.Header())
 	testRPCGetter(ctx, t, "TransactionCount", sut.TransactionCount, want.Hash(), uint(len(want.Transactions())))
+	testRPCMethod(ctx, t, sut, "eth_getUncleCountByBlockHash", hexutil.Uint(0), want.Hash())
 
 	for i, wantTx := range want.Transactions() {
 		t.Run("TransactionByHash", func(t *testing.T) {
@@ -252,6 +253,7 @@ func testGetByNumber(ctx context.Context, t *testing.T, sut *SUT, block *types.B
 	testRPCGetter(ctx, t, "BlockByNumber", sut.BlockByNumber, big.NewInt(number), block)
 	testRPCGetter(ctx, t, "HeaderByNumber", sut.HeaderByNumber, big.NewInt(number), block.Header())
 	testRPCMethod(ctx, t, sut, "eth_getBlockTransactionCountByNumber", hexutil.Uint(len(block.Transactions())), n)
+	testRPCMethod(ctx, t, sut, "eth_getUncleCountByBlockNumber", hexutil.Uint(0), n)
 
 	for i, wantTx := range block.Transactions() {
 		hexIdx := hexutil.Uint(i) //nolint:gosec // definitely won't overflow
@@ -295,14 +297,4 @@ func testRPCMethod[T any](ctx context.Context, t *testing.T, sut *SUT, method st
 			t.Errorf("Diff (-want +got):\n%s", diff)
 		}
 	})
-}
-
-func TestUncleCount(t *testing.T) {
-	ctx, sut := newSUT(t, 1)
-
-	// Create any block (uncle count is always 0 in SAE)
-	block := sut.runConsensusLoop(t, sut.lastAcceptedBlock(t))
-
-	testRPCMethod(ctx, t, sut, "eth_getUncleCountByBlockHash", hexutil.Uint(0), block.Hash())
-	testRPCMethod(ctx, t, sut, "eth_getUncleCountByBlockNumber", hexutil.Uint(0), hexutil.Uint64(block.Height()))
 }


### PR DESCRIPTION
This builds on #83, while adding `GetBody()` to enable block transaction count and uncle count RPC methods.

Adds support for the following Ethereum JSON-RPC methods:                                                                                                                                         
  - `eth_getUncleCountByBlockHash` - always returns 0 (SAE has no uncles)
  - `eth_getUncleCountByBlockNumber` - always returns 0 (SAE has no uncles)
  
 Closes #89 