### PR TITLE
ci: ensure `!prod` and `!nocmpopts` tags don't break the build

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -18,11 +18,22 @@ jobs:
   # what gates PRs.
   go:
     runs-on: ubuntu-latest
-    needs: [go_test, go_generate, go_tidy, require_fuzz_corpus]
+    needs: [go_build_prod, go_test, go_generate, go_tidy, require_fuzz_corpus]
     # TODO(arr4n) investigate why setup-go wasn't properly caching fuzz corpora
     # and then reinstate a go_fuzz job that extends them.
     steps:
       - run: echo "Dependencies successful"
+
+  go_build_prod:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: "go.mod"
+      - run: | # Ensures no leakage of test-only helpers into production code
+          go build -tags prod,nocmpopts -o /dev/null ./...
 
   go_test:
     runs-on: ubuntu-latest

--- a/cmputils/types.go
+++ b/cmputils/types.go
@@ -1,6 +1,8 @@
 // Copyright (C) 2025-2026, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
+//go:build !prod && !nocmpopts
+
 package cmputils
 
 import (


### PR DESCRIPTION
All of the `*/cmpopt.go` files and the entire `cmputils` package have build constraints to avoid them being used in production code, but this was never enforced. If such a file were to be imported by any file that didn't include the `!prod` build constraint then the new CI step would fail.