### PR TITLE
test: add libevm test logger for error promotion

### DIFF
--- a/saetest/logging.go
+++ b/saetest/logging.go
@@ -171,6 +171,8 @@ func (l *TBLogger) log(lvl logging.Level, msg string, fields ...zap.Field) {
 // Logs at [libevmlog.LevelWarn] or above go to [testing.TB.Errorf], except
 // [libevmlog.LevelCrit] which goes to [testing.TB.Fatalf]. All other logs go to
 // [testing.TB.Logf].
+//
+//nolint:thelper // The outputs include the logging site while the TB site is most useful if here
 func NewTBHandler(tb testing.TB) slog.Handler {
 	return &tbHandler{tb: tb}
 }


### PR DESCRIPTION
Closes ava-labs/avalanchego#5271. This adds a test logger for libevm, that treats errors as they _should_ be treated. 

- Logs at `log.LevelWarn` and above trigger `t.Errorf()`, causing tests to fail
- Critical logs fail immediately: Logs at `log.LevelCrit` trigger `t.Fatalf()`                                                               
- Info/debug logs pass through: Lower severity logs use `t.Logf()` for informational output                                                        

You can use the logger like this: 

```go 
  import (                                                                                                                                         
      "github.com/ava-labs/libevm/log"                                                                                                             
      "github.com/ava-labs/strevm/saetest"                                                                                                         
  )                                                                                                                                                
                                                                                                                                                   
  func TestSomething(t *testing.T) {                                                                                                                 
     logger := log.NewLogger(saetest.NewTBHandler(t))                                                                                                 
     
     // Or to set globally                                                                                                                            
     log.SetDefault(log.NewLogger(saetest.NewTBHandler(t)))                                                                                                                                                                                                
  }     
```

I was thinking about adding tests to show this works, but it seemed silly to test a testing utility. 