### PR TITLE
refactor: move invalid-block tests back to main testing function

### DIFF
--- a/sae/rpc_test.go
+++ b/sae/rpc_test.go
@@ -257,7 +257,7 @@ func TestTxPoolNamespace(t *testing.T) {
 	}...)
 }
 
-func TestBlockGetters(t *testing.T) {
+func TestEthGetters(t *testing.T) {
 	opt, vmTime := withVMTime(t, time.Unix(saeparams.TauSeconds, 0))
 
 	ctx, sut := newSUT(t, 1, opt)


### PR DESCRIPTION
`TestBlockGetters` is confusing, as it tests _almost_ all of the cases for the block getters. It makes more sense to me to have that test all of the cases of the function, rather than splitting out some (not so special) edge cases to a different tester