### PR TITLE
test: use `GasPrice()` instead of `GasFeeCap()` in `txpool_inspect` test

### DIFF
--- a/sae/rpc_test.go
+++ b/sae/rpc_test.go
@@ -196,7 +196,7 @@ func TestTxPoolNamespace(t *testing.T) {
 			tx.To(),
 			tx.Value().Uint64(),
 			tx.Gas(),
-			tx.GasFeeCap().Uint64(),
+			tx.GasPrice(),
 		)
 	}
 


### PR DESCRIPTION
Fixes the transaction formatting in `TestTxPoolNamespace` to use `tx.GasPrice()` instead of `tx.GasFeeCap().Uint64()`.