### PR TITLE
feat: Add `ParseGenesis` as initialization hook

### DIFF
--- a/hook/hook.go
+++ b/hook/hook.go
@@ -12,7 +12,7 @@ import (
 	"time"
 
 	"github.com/ava-labs/avalanchego/ids"
-	"github.com/ava-labs/avalanchego/snow"
+	"github.com/ava-labs/avalanchego/upgrade"
 	"github.com/ava-labs/avalanchego/vms/components/gas"
 	"github.com/ava-labs/libevm/common"
 	"github.com/ava-labs/libevm/core"
@@ -33,9 +33,9 @@ type Points interface {
 
 // InitializerPoints define the user-injected hook points for VM initialization.
 type InitializerPoints interface {
-	// ParseGenesis returns the [*core.Genesis] that the VM will use
-	// during initialization.
-	ParseGenesis(ctx *snow.Context, genesisBytes []byte) (*core.Genesis, error)
+	// ApplyNetworkUpgrades set the given chain configuration upgrades
+	// based on the Avalanche upgrade config.
+	ApplyNetworkUpgrades(config *params.ChainConfig, upgrades upgrade.Config) error
 }
 
 // BlockPoints define user-injected hook points for block building, execution,

--- a/hook/hookstest/stub.go
+++ b/hook/hookstest/stub.go
@@ -6,15 +6,12 @@ package hookstest
 
 import (
 	"encoding/binary"
-	"encoding/json"
-	"fmt"
 	"math/big"
 	"time"
 
-	"github.com/ava-labs/avalanchego/snow"
+	"github.com/ava-labs/avalanchego/upgrade"
 	"github.com/ava-labs/avalanchego/vms/components/gas"
 	"github.com/ava-labs/libevm/common"
-	"github.com/ava-labs/libevm/core"
 	"github.com/ava-labs/libevm/core/state"
 	"github.com/ava-labs/libevm/core/types"
 	"github.com/ava-labs/libevm/params"
@@ -101,11 +98,7 @@ func (*Stub) BeforeExecutingBlock(params.Rules, *state.StateDB, *types.Block) er
 // AfterExecutingBlock is a no-op.
 func (*Stub) AfterExecutingBlock(*state.StateDB, *types.Block, types.Receipts) {}
 
-// ParseGenesis parses genesisBytes as JSON with no further modifications.
-func (*Stub) ParseGenesis(_ *snow.Context, genesisBytes []byte) (*core.Genesis, error) {
-	genesis := new(core.Genesis)
-	if err := json.Unmarshal(genesisBytes, genesis); err != nil {
-		return nil, fmt.Errorf("parsing genesis: %w", err)
-	}
-	return genesis, nil
+// ApplyNetworkUpgrades is a no-op that always returns nil.
+func (*Stub) ApplyNetworkUpgrades(config *params.ChainConfig, upgrades upgrade.Config) error {
+	return nil
 }


### PR DESCRIPTION
Adds a `ParseGenesis` hook to allow for custom genesis initialization defined by the consumer.

This allows the consumer to initialize EVM upgrade activation times, as discussed in this [comment](https://github.com/ava-labs/strevm/pull/81#issuecomment-3797074015). I was able to confirm on the AvalancheGo side that providing a `coreth` compatible `ParseGenesis` [implementation](https://github.com/ava-labs/avalanchego/blob/50d638bb02d18ac64bcec0565b86b2a9f756ed1d/vms/saevm/hooks.go#L81) results in newer transaction types being support upon initialization of the SAE VM.