### PR TITLE
test: fix `TestEmptyChainConfig` flake

### DIFF
--- a/sae/vm_test.go
+++ b/sae/vm_test.go
@@ -520,11 +520,10 @@ func TestEmptyChainConfig(t *testing.T) {
 			ChainID: big.NewInt(42),
 		}
 	}))
-	var b *blocks.Block
 	for range 5 {
-		b = sut.runConsensusLoop(t, sut.lastAcceptedBlock(t))
+		sut.runConsensusLoop(t, sut.lastAcceptedBlock(t))
 	}
-	sut.waitUntilExecuted(t, b)
+	sut.waitUntilExecuted(t, sut.lastAcceptedBlock(t))
 }
 
 func TestSyntacticBlockChecks(t *testing.T) {


### PR DESCRIPTION
Closes #165. 

`TestEmptyChainConfig` flaked in CI with `error:closed` when the async executor tried to write to the database via `MarkExecuted()` after the underlying memdb was closed during test cleanup. This happens because the test acepts 5 blocks but never waited for the executor to finish executing them. When the test function returns, cleanup runs and closes resources while the executor was still mid-execution. This then causes the `batch.Write()` inside `MarkExecuted()` to try to hit a closed memdb (`database.ErrClosed`), which then fails.

The fix is to just add a `sut.waitUntilExecuted(t, b)` after the loop to ensure all accepted blocks finish executing before the test exits and cleanup runs. This matches the pattern used by every other test in the codebase that accepts blocks. 