### PR TITLE
test: `saexec.TestGasAccounting` asserts `Receipt.EffectiveGasPrice`

### DIFF
--- a/saexec/saexec_test.go
+++ b/saexec/saexec_test.go
@@ -418,6 +418,7 @@ func TestGasAccounting(t *testing.T) {
 	steps := []struct {
 		blockTime      uint64
 		numTxs         int
+		gasTipCap      uint64
 		targetAfter    gas.Gas
 		wantExecutedBy *proxytime.Time[gas.Gas]
 		// Because of the 2:1 ratio between Rate and Target, gas consumption
@@ -496,6 +497,7 @@ func TestGasAccounting(t *testing.T) {
 		{
 			blockTime:       22, // no fast-forward
 			numTxs:          10 * gastime.TargetToExcessScaling,
+			gasTipCap:       1, // anything non-zero, to exercise [types.Receipt.EffectiveGasPrice]
 			targetAfter:     5 * gasPerTx,
 			wantExecutedBy:  at(21, 40*gastime.TargetToExcessScaling, 10*gasPerTx),
 			wantExcessAfter: 4 * ((5 * gasPerTx /*T*/) * gastime.TargetToExcessScaling /* == K */),
@@ -505,6 +507,13 @@ func TestGasAccounting(t *testing.T) {
 
 	e, chain, wallet := sut.Executor, sut.chain, sut.wallet
 
+	var maxGasFeeCap uint64
+	price := gas.Price(1)
+	for _, s := range steps {
+		maxGasFeeCap = max(maxGasFeeCap, uint64(price)+s.gasTipCap)
+		price = s.wantPriceAfter
+	}
+
 	for i, step := range steps {
 		hooks.Target = step.targetAfter
 
@@ -513,8 +522,8 @@ func TestGasAccounting(t *testing.T) {
 			txs[i] = wallet.SetNonceAndSign(t, 0, &types.DynamicFeeTx{
 				To:        &common.Address{},
 				Gas:       params.TxGas,
-				GasTipCap: big.NewInt(0),
-				GasFeeCap: big.NewInt(100),
+				GasTipCap: uint256.NewInt(step.gasTipCap).ToBig(),
+				GasFeeCap: uint256.NewInt(maxGasFeeCap).ToBig(),
 			})
 		}
 
@@ -555,6 +564,15 @@ func TestGasAccounting(t *testing.T) {
 			}
 			require.Truef(t, b.BaseFee().IsUint64(), "%T.BaseFee().IsUint64()", b)
 			assert.Equalf(t, wantBaseFee, gas.Price(b.BaseFee().Uint64()), "%T.BaseFee().Uint64()", b)
+
+			t.Run("EffectiveGasPrice", func(t *testing.T) {
+				want := uint256.NewInt(uint64(wantBaseFee) + step.gasTipCap)
+				for i, r := range b.Receipts() {
+					if got := r.EffectiveGasPrice; got.Cmp(want.ToBig()) != 0 {
+						t.Errorf("%T.Receipts()[%d].EffectiveGasPrice = %v; want %v", b, i, got, want)
+					}
+				}
+			})
 		})
 	}
 	if t.Failed() {


### PR DESCRIPTION
These tests are price-specific whereas all others have a base fee of 1.