### PR TITLE
chore: unembed `ethapi.Backend`

### DIFF
--- a/sae/rpc.go
+++ b/sae/rpc.go
@@ -253,7 +253,7 @@ type ethAPIBackend struct {
 	*bloomIndexer
 }
 
-var _ ethapi.Backend = (*ethAPIBackend)(nil)
+var _ APIBackend = (*ethAPIBackend)(nil)
 
 func (b *ethAPIBackend) ChainConfig() *params.ChainConfig {
 	return b.vm.exec.ChainConfig()

--- a/sae/temporary.go
+++ b/sae/temporary.go
@@ -10,20 +10,14 @@ import (
 	"context"
 	"errors"
 	"math/big"
-	"time"
 
 	"github.com/ava-labs/libevm/common"
-	"github.com/ava-labs/libevm/consensus"
-	"github.com/ava-labs/libevm/core"
-	"github.com/ava-labs/libevm/core/state"
 	"github.com/ava-labs/libevm/core/types"
-	"github.com/ava-labs/libevm/core/vm"
 	"github.com/ava-labs/libevm/ethdb"
 	"github.com/ava-labs/libevm/rpc"
 )
 
 var errUnimplemented = errors.New("unimplemented")
-
 
 func (b *ethAPIBackend) SuggestGasTipCap(context.Context) (*big.Int, error) {
 	panic(errUnimplemented)
@@ -41,14 +35,6 @@ func (b *ethAPIBackend) ExtRPCEnabled() bool {
 	panic(errUnimplemented)
 }
 
-func (b *ethAPIBackend) RPCGasCap() uint64 {
-	panic(errUnimplemented)
-}
-
-func (b *ethAPIBackend) RPCEVMTimeout() time.Duration {
-	panic(errUnimplemented)
-}
-
 func (b *ethAPIBackend) SetHead(uint64) {
 	panic(errUnimplemented)
 }
@@ -61,14 +47,6 @@ func (b *ethAPIBackend) BlockByNumberOrHash(context.Context, rpc.BlockNumberOrHa
 	panic(errUnimplemented)
 }
 
-func (b *ethAPIBackend) StateAndHeaderByNumber(context.Context, rpc.BlockNumber) (*state.StateDB, *types.Header, error) {
-	panic(errUnimplemented)
-}
-
-func (b *ethAPIBackend) StateAndHeaderByNumberOrHash(context.Context, rpc.BlockNumberOrHash) (*state.StateDB, *types.Header, error) {
-	panic(errUnimplemented)
-}
-
 func (b *ethAPIBackend) PendingBlockAndReceipts() (*types.Block, types.Receipts) {
 	panic(errUnimplemented)
 }
@@ -77,14 +55,6 @@ func (b *ethAPIBackend) GetReceipts(context.Context, common.Hash) (types.Receipt
 	panic(errUnimplemented)
 }
 
-func (b *ethAPIBackend) GetEVM(context.Context, *core.Message, *state.StateDB, *types.Header, *vm.Config, *vm.BlockContext) *vm.EVM {
-	panic(errUnimplemented)
-}
-
 func (b *ethAPIBackend) GetPoolNonce(context.Context, common.Address) (uint64, error) {
-	panic(errUnimplemented)
-}
-
-func (b *ethAPIBackend) Engine() consensus.Engine {
 	panic(errUnimplemented)
 }


### PR DESCRIPTION
As the title states! Note that the organization of these functions could be much better, including functions we've already fully implemented -- I just slapped all the remaining ones at the bottom. 

We should seriously reorganize this file with a refactor. 