### PR TITLE
chore: skip extra disk read

### DIFF
--- a/blocks/execution.go
+++ b/blocks/execution.go
@@ -290,3 +290,13 @@ func PostExecutionStateRoot(xdb saedb.ExecutionResults, blockNum uint64) (common
 func ExecutionBaseFee(xdb saedb.ExecutionResults, blockNum uint64) (*uint256.Int, error) {
 	return persistedExecutionArtefact(xdb, blockNum, (*executionResults).cloneBaseFee)
 }
+
+// StateRootAndBaseFee loads persisted execution results once and returns both
+// the post-execution state root and base fee.
+func StateRootAndBaseFee(xdb saedb.ExecutionResults, blockNum uint64) (common.Hash, *uint256.Int, error) {
+	e, err := loadExecutionResults(xdb, blockNum)
+	if err != nil {
+		return common.Hash{}, nil, err
+	}
+	return e.postExecutionStateRoot(), e.cloneBaseFee(), nil
+}

--- a/sae/rpc_stateful.go
+++ b/sae/rpc_stateful.go
@@ -83,18 +83,11 @@ func (b *ethAPIBackend) StateAndHeaderByNumberOrHash(ctx context.Context, numOrH
 	} else {
 		hdr = rawdb.ReadHeader(b.db, hash, num)
 
-		// TODO(arr4n) export [blocks.executionResults] to avoid multiple
-		// database reads and canoto unmarshallings here.
-		var err error
-		hdr.Root, err = blocks.PostExecutionStateRoot(b.vm.xdb, num)
+		root, bf, err := blocks.StateRootAndBaseFee(b.vm.xdb, num)
 		if err != nil {
 			return nil, nil, err
 		}
-
-		bf, err := blocks.ExecutionBaseFee(b.vm.xdb, num)
-		if err != nil {
-			return nil, nil, err
-		}
+		hdr.Root = root
 		hdr.BaseFee = bf.ToBig()
 	}
 


### PR DESCRIPTION
Closes ava-labs/avalanchego#5260. 

When falling back to the DB, `PostExecutionStateRoot` and `ExecutionBaseFee` each read and unmarshal the same `executionResults` record separately, which is inefficient. We can add a helper that returns both values so the record only needs to be read and decoded once.