### PR TITLE
refactor: rationalise usage of `sae.SUT.runConsensusLoop()`

### DIFF
--- a/sae/recovery_test.go
+++ b/sae/recovery_test.go
@@ -62,7 +62,7 @@ func TestRecoverFromDatabase(t *testing.T) {
 		}
 
 		vmTime.advance(850 * time.Millisecond)
-		b := src.runConsensusLoop(t, src.lastAcceptedBlock(t))
+		b := src.runConsensusLoop(t)
 		if !quick {
 			require.Len(t, b.Transactions(), 1, "transactions in block")
 		}
@@ -113,7 +113,7 @@ func TestRecoverFromDatabase(t *testing.T) {
 					} {
 						t.Run(sys.name, func(t *testing.T) {
 							sys.mustSendTx(t, tx)
-							b := sys.runConsensusLoop(t, sys.lastAcceptedBlock(t))
+							b := sys.runConsensusLoop(t)
 							require.Len(t, b.Transactions(), 1)
 							require.NoError(t, b.WaitUntilExecuted(sys.ctx))
 						})

--- a/sae/rpc_stateful_test.go
+++ b/sae/rpc_stateful_test.go
@@ -43,7 +43,7 @@ func TestEthCall(t *testing.T) {
 	}
 
 	sign := sut.wallet.SetNonceAndSign
-	b := sut.runConsensusLoopFromLastAccepted(t, sign(t, 0, deploy), sign(t, 0, deposit))
+	b := sut.runConsensusLoop(t, sign(t, 0, deploy), sign(t, 0, deposit))
 	require.Len(t, b.Transactions(), 2, "tx count")
 	require.NoErrorf(t, b.WaitUntilExecuted(ctx), "%T.WaitUntilExecuted()", b)
 	for _, r := range b.Receipts() {
@@ -52,7 +52,7 @@ func TestEthCall(t *testing.T) {
 
 	vmTime.advanceToSettle(ctx, t, b)
 	for range 2 {
-		bb := sut.runConsensusLoop(t, sut.lastAcceptedBlock(t))
+		bb := sut.runConsensusLoop(t)
 		vmTime.advanceToSettle(ctx, t, bb)
 	}
 	_, ok := sut.rawVM.blocks.Load(b.Hash())

--- a/sae/rpc_test.go
+++ b/sae/rpc_test.go
@@ -166,7 +166,7 @@ func TestSubscriptions(t *testing.T) {
 	runConsensusLoop := func(wantLogs ...types.Log) {
 		t.Helper()
 
-		b := sut.runConsensusLoop(t, sut.lastAcceptedBlock(t))
+		b := sut.runConsensusLoop(t)
 		require.Equal(t, b.Hash(), (<-newHeads).Hash(), "header hash from newHeads subscription")
 
 		for _, want := range wantLogs {
@@ -423,28 +423,23 @@ func TestEthGetters(t *testing.T) {
 	blockingPrecompile := common.Address{'b', 'l', 'o', 'c', 'k'}
 	registerBlockingPrecompile(t, blockingPrecompile)
 
-	createTx := func(t *testing.T, to common.Address) *types.Transaction {
-		t.Helper()
-		return sut.wallet.SetNonceAndSign(t, 0, &types.DynamicFeeTx{
-			To:        &to,
-			Gas:       params.TxGas,
-			GasFeeCap: big.NewInt(1),
-		})
-	}
-
 	genesis := sut.lastAcceptedBlock(t)
 
 	// Once a block is settled, its ancestors are only accessible from the
 	// database.
-	onDisk := sut.runConsensusLoopFromLastAccepted(t, createTx(t, zeroAddr))
+	onDisk := sut.runConsensusLoop(t)
 
-	settled := sut.runConsensusLoopFromLastAccepted(t, createTx(t, zeroAddr))
+	settled := sut.runConsensusLoop(t)
 	vmTime.advanceToSettle(ctx, t, settled)
 
-	executed := sut.runConsensusLoopFromLastAccepted(t, createTx(t, zeroAddr))
+	executed := sut.runConsensusLoop(t)
 	require.NoErrorf(t, executed.WaitUntilExecuted(ctx), "%T.WaitUntilExecuted()", executed)
 
-	pending := sut.runConsensusLoopFromLastAccepted(t, createTx(t, blockingPrecompile))
+	pending := sut.runConsensusLoop(t, sut.wallet.SetNonceAndSign(t, 0, &types.DynamicFeeTx{
+		To:        &blockingPrecompile,
+		Gas:       params.TxGas,
+		GasFeeCap: big.NewInt(1),
+	}))
 
 	for _, b := range []*blocks.Block{genesis, onDisk, settled, executed, pending} {
 		t.Run(fmt.Sprintf("block_num_%d", b.Height()), func(t *testing.T) {
@@ -532,15 +527,15 @@ func TestGetLogs(t *testing.T) {
 	// and therefore moved to disk.
 	indexed := make([]*blocks.Block, bloomSectionSize)
 	for i := range indexed {
-		indexed[i] = sut.runConsensusLoopFromLastAccepted(t, txWithLog(t))
+		indexed[i] = sut.runConsensusLoop(t, txWithLog(t))
 	}
 
-	settled := sut.runConsensusLoopFromLastAccepted(t, txWithLog(t))
+	settled := sut.runConsensusLoop(t, txWithLog(t))
 	vmTime.advanceToSettle(ctx, t, settled)
 
-	noLogs := sut.runConsensusLoopFromLastAccepted(t, txWithoutLog(t))
+	noLogs := sut.runConsensusLoop(t, txWithoutLog(t))
 
-	executed := sut.runConsensusLoopFromLastAccepted(t, txWithLog(t))
+	executed := sut.runConsensusLoop(t, txWithLog(t))
 	require.NoErrorf(t, executed.WaitUntilExecuted(ctx), "%T.WaitUntilExecuted()", executed)
 
 	// Although the FiltersAPI will work without any blocks indexed, such a
@@ -698,7 +693,7 @@ func TestGetReceipts(t *testing.T) {
 
 	slice := func(t *testing.T, from, to int) (*blocks.Block, []*types.Receipt) {
 		t.Helper()
-		b := sut.runConsensusLoopFromLastAccepted(t, txs[from:to]...)
+		b := sut.runConsensusLoop(t, txs[from:to]...)
 		rs := want[from:to]
 
 		var totalGas uint64
@@ -725,7 +720,7 @@ func TestGetReceipts(t *testing.T) {
 		Gas:      params.TxGas,
 		GasPrice: big.NewInt(1),
 	})
-	pending := sut.runConsensusLoopFromLastAccepted(t, pendingTx)
+	pending := sut.runConsensusLoop(t, pendingTx)
 
 	var tests []rpcTest
 	for _, tc := range []struct {
@@ -913,7 +908,7 @@ func TestDebugGetRawTransaction(t *testing.T) {
 		Gas:       params.TxGas,
 		GasFeeCap: big.NewInt(1),
 	})
-	b := sut.runConsensusLoopFromLastAccepted(t, tx)
+	b := sut.runConsensusLoop(t, tx)
 	require.NoErrorf(t, b.WaitUntilExecuted(ctx), "%T.WaitUntilExecuted()", b)
 
 	marshaled, err := tx.MarshalBinary()
@@ -1179,17 +1174,17 @@ func TestResolveBlockNumberOrHash(t *testing.T) {
 	opt, vmTime := withVMTime(t, time.Unix(saeparams.TauSeconds, 0))
 	ctx, sut := newSUT(t, 0, opt)
 
-	settled := sut.runConsensusLoop(t, sut.lastAcceptedBlock(t))
+	settled := sut.runConsensusLoop(t)
 	vmTime.advanceToSettle(ctx, t, settled)
 
 	for range 2 {
-		b := sut.runConsensusLoop(t, sut.lastAcceptedBlock(t))
+		b := sut.runConsensusLoop(t)
 		vmTime.advanceToSettle(ctx, t, b)
 	}
 	_, ok := sut.rawVM.blocks.Load(settled.Hash())
 	require.False(t, ok, "settled block still in VM memory")
 
-	accepted := sut.runConsensusLoop(t, sut.lastAcceptedBlock(t))
+	accepted := sut.runConsensusLoop(t)
 	require.NoError(t, sut.SetPreference(ctx, accepted.ID()), "SetPreference()")
 
 	b, err := sut.BuildBlock(ctx)

--- a/sae/tx_test.go
+++ b/sae/tx_test.go
@@ -44,7 +44,7 @@ func TestTxTypeSupport(t *testing.T) {
 			t.FailNow()
 		}
 	}
-	b := sut.runConsensusLoop(t, sut.genesis)
+	b := sut.runConsensusLoop(t)
 	require.NoErrorf(t, b.WaitUntilExecuted(ctx), "%T.WaitUntilExecuted()", b)
 
 	sdb := sut.stateAt(t, b.PostExecutionStateRoot())

--- a/sae/worstcase_test.go
+++ b/sae/worstcase_test.go
@@ -175,7 +175,7 @@ func TestWorstCase(t *testing.T) {
 			}))
 		}
 
-		b := sut.runConsensusLoop(t, sut.genesis)
+		b := sut.runConsensusLoop(t)
 		require.NoError(t, b.WaitUntilExecuted(ctx), "%T.WaitUntilExecuted()", b)
 		require.Lenf(t, b.Receipts(), len(precompileTests), "%T.Receipts()", b)
 		for i, r := range b.Receipts() {


### PR DESCRIPTION
1. Renames `SUT.runConsensusLoop()` to `runConsensusLoopOnPreference()` to allow (2).
2. Renames `runConsensusLoopFromLastAccepted()` to `runConsensusLoop()` as it's used so frequently that it should be the shorter, generic method.
3. Simplifies all usage of `runConsensusLoopOnPreference(..., sut.lastAcceptedBlock(t) / sut.genesis)` to just `runConsensusLoop()`.
4. Where appropriate, removes unnecessary transactions passed to `runConsensusLoop()`.