### PR TITLE
chore: add tracers stubs

### DIFF
--- a/sae/rpc.go
+++ b/sae/rpc.go
@@ -175,7 +175,7 @@ func (vm *VM) ethRPCServer() (*rpc.Server, error) {
 		})
 	}
 
-	if vm.config.RPCConfig.EnableTracing {
+	if !vm.config.RPCConfig.DisableTracing {
 		apis = append(apis, api{
 			// Geth-specific APIs:
 			"debug", tracers.NewAPI(b),

--- a/sae/temporary.go
+++ b/sae/temporary.go
@@ -42,10 +42,10 @@ func (b *ethAPIBackend) GetPoolNonce(context.Context, common.Address) (uint64, e
 	panic(errUnimplemented)
 }
 
-func (b *ethAPIBackend) StateAtBlock(context.Context, *types.Block, uint64, *state.StateDB, bool, bool) (*state.StateDB, tracers.StateReleaseFunc, error) {
+func (b *ethAPIBackend) StateAtBlock(ctx context.Context, block *types.Block, reexec uint64, base *state.StateDB, readOnly bool, preferDisk bool) (*state.StateDB, tracers.StateReleaseFunc, error) {
 	panic(errUnimplemented)
 }
 
-func (b *ethAPIBackend) StateAtTransaction(context.Context, *types.Block, int, uint64) (*core.Message, vm.BlockContext, *state.StateDB, tracers.StateReleaseFunc, error) {
+func (b *ethAPIBackend) StateAtTransaction(ctx context.Context, block *types.Block, txIndex int, reexec uint64) (*core.Message, vm.BlockContext, *state.StateDB, tracers.StateReleaseFunc, error) {
 	panic(errUnimplemented)
 }

--- a/sae/vm.go
+++ b/sae/vm.go
@@ -91,7 +91,7 @@ type RPCConfig struct {
 	BlocksPerBloomSection uint64
 	EnableDBInspecting    bool
 	EnableProfiling       bool
-	EnableTracing         bool
+	DisableTracing        bool
 	EVMTimeout            time.Duration
 	GasCap                uint64
 }


### PR DESCRIPTION
While all other stubs were present in `temporary.go`, these two methods were missing. This sets up the config, and makes clear all the RPC methods that still need to be implemented. 