### PR TITLE
feat: `eth_getTransactionReceipt` waits for txs in mempool

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -36,7 +36,6 @@ linters:
     - testableexamples
     - testifylint
     - thelper
-    - tparallel
     - unconvert
     - usestdlibvars
     - unused

--- a/sae/recovery_test.go
+++ b/sae/recovery_test.go
@@ -29,6 +29,8 @@ import (
 )
 
 func TestRecoverFromDatabase(t *testing.T) {
+	t.Parallel()
+
 	sutOpt, vmTime := withVMTime(t, time.Unix(saeparams.TauSeconds, 0))
 
 	var srcDB database.Database

--- a/sae/rpc.go
+++ b/sae/rpc.go
@@ -119,7 +119,7 @@ func (vm *VM) ethRPCServer() (*rpc.Server, error) {
 		{
 			"eth",
 			immediateReceipts{
-				vm.exec,
+				vm,
 				ethapi.NewTransactionAPI(b, new(ethapi.AddrLocker)),
 			},
 		},

--- a/sae/rpc_receipts.go
+++ b/sae/rpc_receipts.go
@@ -9,31 +9,54 @@ import (
 	"github.com/ava-labs/libevm/common"
 	"github.com/ava-labs/libevm/libevm/ethapi"
 
+	"github.com/ava-labs/strevm/blocks"
 	"github.com/ava-labs/strevm/saexec"
 )
 
 type immediateReceipts struct {
-	exec *saexec.Executor
+	vm *VM
 	*ethapi.TransactionAPI
 }
 
 func (ir immediateReceipts) GetTransactionReceipt(ctx context.Context, h common.Hash) (map[string]any, error) {
-	r, ok, err := ir.exec.RecentReceipt(ctx, h)
-	if err != nil {
-		return nil, err
+	var _ *saexec.Executor // protect the import for IDE comment resolution
+
+	// [saexec.Executor.RecentReceipt] will only return false if the transaction
+	// is yet to be included in an accepted block, or if it was executed so long
+	// ago that it is no longer in the cache. Assuming a tx "known" to the
+	// network, the former implies that it is in the mempool and the latter
+	// requires a fallback to regular receipt retrieval. Since
+	// [saexec.Executor.Enqueue] returning without error guarantees that
+	// RecentReceipt() will return known, still-cached receipts, we only have to
+	// handle the unknown ones.
+
+	// A buffer of 1 avoids a race between our call to RecentReceipt() and a
+	// concurrent call to Enqueue() by [VM.AcceptBlock], which only sends an
+	// `accepted` event after enqueuing.
+	ch := make(chan *blocks.Block, 1)
+	sub := ir.vm.exec.SubscribeEnqueueEvent(ch)
+	defer sub.Unsubscribe()
+
+	for ; ; <-ch {
+		// The mempool might have dropped the tx for reasons other than block
+		// inclusion, in which case we'll fall back on regular receipt retrival,
+		// which already handles unknown transactions.
+		known := ir.vm.mempool.Pool.Has(h)
+
+		r, ok, err := ir.vm.exec.RecentReceipt(ctx, h)
+		if err != nil {
+			return nil, err
+		}
+		if ok {
+			return r.MarshalForRPC(), nil
+		}
+		if !known {
+			return ir.TransactionAPI.GetTransactionReceipt(ctx, h)
+		}
+
+		// 'Cause if at first you don't succeed
+		// You can dust it off and try again
+		// Dust yourself off and try again, try again
+		// 𝄢 ♪♩♪♩♩|♪♩♪♩♩
 	}
-	if !ok {
-		// The transaction has either not been included yet, or it was cleared
-		// from the [saexec.Executor] cache but is on disk. The standard
-		// mechanism already differentiates between these scenarios.
-		return ir.TransactionAPI.GetTransactionReceipt(ctx, h)
-	}
-	return ethapi.MarshalReceipt(
-		r.Receipt,
-		r.BlockHash,
-		r.BlockNumber.Uint64(),
-		r.Signer,
-		r.Tx,
-		int(r.TransactionIndex), //nolint:gosec // Known to not overflow
-	), nil
 }

--- a/sae/worstcase_test.go
+++ b/sae/worstcase_test.go
@@ -110,7 +110,6 @@ func (g *guzzler) guzzle(env vm.PrecompileEnvironment, input []byte) ([]byte, er
 	return nil, nil
 }
 
-//nolint:tparallel // Why should we call t.Parallel at the top level by default?
 func TestWorstCase(t *testing.T) {
 	flags := worstCaseFuzzFlags
 	t.Logf("Flags: %+v", flags)

--- a/saexec/receipts.go
+++ b/saexec/receipts.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/ava-labs/libevm/common"
 	"github.com/ava-labs/libevm/core/types"
+	"github.com/ava-labs/libevm/libevm/ethapi"
 
 	"github.com/ava-labs/strevm/blocks"
 )
@@ -43,6 +44,19 @@ type Receipt struct {
 	*types.Receipt
 	Signer types.Signer
 	Tx     *types.Transaction
+}
+
+// MarshalForRPC returns [ethapi.MarshalReceipt] with all arguments sourced from
+// `r`.
+func (r *Receipt) MarshalForRPC() map[string]any {
+	return ethapi.MarshalReceipt(
+		r.Receipt,
+		r.BlockHash,
+		r.BlockNumber.Uint64(),
+		r.Signer,
+		r.Tx,
+		int(r.TransactionIndex), //nolint:gosec // Known to not overflow
+	)
 }
 
 // RecentReceipt returns the receipt for the specified [types.Transaction] hash,

--- a/saexec/saexec.go
+++ b/saexec/saexec.go
@@ -40,10 +40,11 @@ type Executor struct {
 	queue        chan *blocks.Block
 	lastExecuted atomic.Pointer[blocks.Block]
 
-	headEvents  event.FeedOf[core.ChainHeadEvent]
-	chainEvents event.FeedOf[core.ChainEvent]
-	logEvents   event.FeedOf[[]*types.Log]
-	receipts    *syncMap[common.Hash, chan *Receipt]
+	enqueueEvents event.FeedOf[*blocks.Block]
+	headEvents    event.FeedOf[core.ChainHeadEvent]
+	chainEvents   event.FeedOf[core.ChainEvent]
+	logEvents     event.FeedOf[[]*types.Log]
+	receipts      *syncMap[common.Hash, chan *Receipt]
 
 	chainContext *chainContext
 	chainConfig  *params.ChainConfig

--- a/saexec/subscription.go
+++ b/saexec/subscription.go
@@ -7,7 +7,15 @@ import (
 	"github.com/ava-labs/libevm/core"
 	"github.com/ava-labs/libevm/core/types"
 	"github.com/ava-labs/libevm/event"
+
+	"github.com/ava-labs/strevm/blocks"
 )
+
+// SubscribeEnqueueEvent returns a new subscription for each block for which
+// [Executor.Enqueue] returns successfully.
+func (e *Executor) SubscribeEnqueueEvent(ch chan<- *blocks.Block) event.Subscription {
+	return e.enqueueEvents.Subscribe(ch)
+}
 
 func (e *Executor) sendPostExecutionEvents(b *types.Block, receipts types.Receipts) {
 	e.headEvents.Send(core.ChainHeadEvent{Block: b})


### PR DESCRIPTION
A typical user flow is to call `eth_sendRawTransaction` and then poll `eth_getTransactionReceipt`. While #169 removed the need for polling as long as the transaction was already included in an accepted block, that left the opportunity for a race between block acceptance and the call to `eth_getTransactionReceipt`. This PR addresses the race.

An open question is whether or not we want to add a timeout to the `Context`. If we do then we SHOULD NOT return `ctx.Err()` because "deadline exceeded" will be interpreted incorrectly.

In testing, I have no idea how to guarantee that the block is accepted _after_ the call to `GetTransactionReceipt()` is initiated without instrumenting the function itself. Since there is another, longer-running test, I simply marked both as parallel. In doing so, I disabled the `tparallel` linter because of stupid recommendations.