### PR TITLE
test: fix fuzz caching

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -89,29 +89,27 @@ jobs:
       - uses: actions/checkout@v4
       - id: find
         run: |
-          echo "targets=$(grep --recursive --include '**_test.go' -oP "^func \KFuzz[^(]+" | xargs jq -c -n '$ARGS.positional' --args)" >> $GITHUB_OUTPUT
+          targets=$(grep --recursive --include '**_test.go' -oP "^func \KFuzz[^(]+" | while IFS=: read -r file func; do
+            jq -c -n --arg p "$(dirname "$file")" --arg f "$func" '{package: $p, function: $f}'
+          done | jq -c -s '.')
+          echo "targets=${targets}" >> $GITHUB_OUTPUT
 
   go_fuzz:
     needs: [find_fuzz_targets]
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        target: ${{fromJSON(needs.find_fuzz_targets.outputs.targets)}}
+        include: ${{fromJSON(needs.find_fuzz_targets.outputs.targets)}}
     env:
+      PACKAGE: ${{ matrix.package }}
+      FUNCTION: ${{ matrix.function }}
+      CORPUS_DIR: ./${{ matrix.package }}/testdata/fuzz/${{ matrix.function }}
       # The actual corpus size is dependent on the test in question and how many
       # "interesting" cases can be found. This is an arbitrary lower bound,
       # chosen as approximately half the size of the very basic
       # `FuzzEffectiveGasTip`.
       MIN_CORPUS_SIZE: 20
     steps:
-      - name: Parse fuzz target
-        env:
-          TARGET: ${{ matrix.target }}
-        run: |
-          echo "$TARGET" | awk -F: '{print $1}' | xargs dirname | xargs -I{} echo "PACKAGE={}" >> "$GITHUB_ENV"
-          echo "$TARGET" | awk -F: '{print $2}' | xargs -I{} echo "FUNCTION={}" >> "$GITHUB_ENV"
-      - run: |
-          echo "CORPUS_DIR=./${PACKAGE}/testdata/fuzz/${FUNCTION}" >> "$GITHUB_ENV"
       - uses: actions/checkout@v4
       - name: Require existing corpus of at least ${MIN_CORPUS_SIZE}
         run: | # Raw `go test` will be meaningful, and `-fuzz` won't start from nowhere
@@ -126,7 +124,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ${{ env.GOCACHE }}/fuzz
-          key: fuzz-corpus-${{ env.PACKAGE }}-${{ env.FUNCTION }}-${{ hashFiles(format('{0}/testdata/fuzz/{1}/**', env.PACKAGE, env.FUNCTION)) }}
+          key: fuzz-corpus-${{ matrix.package }}-${{ matrix.function }}-${{ hashFiles(format('{0}/testdata/fuzz/{1}/**', matrix.package, matrix.function)) }}
           restore-keys: |
-            fuzz-corpus-${{ env.PACKAGE }}-${{ env.FUNCTION }}-
+            fuzz-corpus-${{ matrix.package }}-${{ matrix.function }}-
       - run: go test ./${PACKAGE} -fuzz=${FUNCTION} -fuzztime=30s


### PR DESCRIPTION
## Issue 

This PR reinstates the `go_fuzz` CI job that was removed in #46. The original job relied on setup-go's implicit caching of `GOCACHE` (which includes the fuzz subdirectory) but the fuzz corpus wasn't persisting across runs. This adds a dedicated `actions/cache` step with a per-function key independent of the `go.mod`, so the corpus accumulates reliably across CI runs.

Note that while there are environment variables for other Go caches, there's no go fuzz cache that would make this a lot easier -- see this longstanding issue: https://github.com/golang/go/issues/48901

This PR also fixes `require_fuzz_corpus` where the `${{ matrix.target }}` was consumed into the shell commands directly. I made both jobs use an `env: block`, which I believe is better practice and cleaner. 

## Testing 
 
I tested this works running the fuzz tests locally and verifying the cache was written to `$GOCACHE/fuzz/`. We see this also works in CI in the second workflow run (a reun) through `"Cache restored from key: fuzz-corpus-Linux-FuzzEffectiveGasTip-..."`. See the run [here](https://github.com/ava-labs/strevm/actions/runs/22635004856/job/65595900510?pr=256). 

<img width="1276" height="244" alt="Screenshot 2026-03-03 at 12 36 27 PM" src="https://github.com/user-attachments/assets/1bba00a1-2918-4791-9802-32997146684f" />

We can also verify it works in CI in an entirely new run (a new commit, eabf536), where the primary key is missed, but the restore key is matched. 

<img width="1269" height="431" alt="Screenshot 2026-03-03 at 12 47 08 PM" src="https://github.com/user-attachments/assets/04872d01-8c58-4db3-9d8c-e693681ac896" />

----

Closes #209