### PR TITLE
fix: fuzz cache stores new runs

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -124,7 +124,6 @@ jobs:
         run: |
           CORPUS_KEY="${{ matrix.package }}-${{ matrix.function }}_static-corpus_${{ hashFiles(format('{0}/testdata/fuzz/{1}/**', matrix.package, matrix.function)) }}"
           COMMIT_KEY="${CORPUS_KEY}_commit_${{ github.sha }}"
-          echo "TEST_KEY=${TEST_KEY}" >> "$GITHUB_ENV"
           echo "CORPUS_KEY=${CORPUS_KEY}" >> "$GITHUB_ENV"
           echo "COMMIT_KEY=${COMMIT_KEY}" >> "$GITHUB_ENV"
       - name: Restore fuzz corpus cache


### PR DESCRIPTION
Although the extended fuzz corpora were being loaded from the cache, they weren't being extended beyond a single run because of a perfect cache hit. The new key will extend the corpus on every run, defaulting to a recent run with the same static corpus. It doesn't ever resort to a key not based on the static corpus because that might hit one with incompatible arguments, and we use a change in the static corpus as a signal of new arguments.