### PR TITLE
Revert "chore: use pool for channels"

### DIFF
--- a/saexec/receipts.go
+++ b/saexec/receipts.go
@@ -21,7 +21,6 @@ func (e *Executor) createReceiptBuffers(b *blocks.Block) {
 	for i, tx := range b.Transactions() {
 		txs[i] = tx.Hash()
 	}
-	// TODO(arr4n) consider a pool for reusing channels.
 	e.receipts.StoreFromFunc(func(common.Hash) chan *Receipt {
 		return make(chan *Receipt, 1)
 	}, txs...)


### PR DESCRIPTION
Reverts ava-labs/strevm#265

This PR introduced a very subtle race-condition.

If the block is GCed while someone is looking for a receipt in that block, then that call may still have a reference to this channel.

This could result in incorrectly blocking (preventing the receipt from being returned). Or, worse, the wrong receipt could have been returned after the channel was returned from the pool.