### PR TITLE
refactor: use `eventual.Value` for immediate receipts

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ tool github.com/go-task/task/v3/cmd/task
 require (
 	github.com/arr4n/shed v0.0.0-20260217105731-4cd15adfa100
 	github.com/ava-labs/avalanchego v1.14.2-0.20260123184805-18c4dbe2714e
-	github.com/ava-labs/libevm v1.13.15-0.20260218120213-98a792673af1
+	github.com/ava-labs/libevm v1.13.15-0.20260306175353-3ee189cbd80d
 	github.com/google/go-cmp v0.7.0
 	github.com/holiman/uint256 v1.2.4
 	github.com/stretchr/testify v1.11.1

--- a/go.sum
+++ b/go.sum
@@ -42,8 +42,8 @@ github.com/arr4n/shed v0.0.0-20260217105731-4cd15adfa100 h1:j0Pj/Gq5XTbJEyzoSX82
 github.com/arr4n/shed v0.0.0-20260217105731-4cd15adfa100/go.mod h1:eD5UkxiWTdbkqM7mg2Xf981SAeWQ/Q80js/1rFcKpfg=
 github.com/ava-labs/avalanchego v1.14.2-0.20260123184805-18c4dbe2714e h1:vmO2RL0wG6QuMxZqSzY13BtR77XsSCcCmiwPKCJkAXI=
 github.com/ava-labs/avalanchego v1.14.2-0.20260123184805-18c4dbe2714e/go.mod h1:aE2RZUWfJwiK+tyVu+fnE5DWOZ0W1TEg5BL3n1rkq7s=
-github.com/ava-labs/libevm v1.13.15-0.20260218120213-98a792673af1 h1:atwjfn1w3KH6wjDvvURfEncCQR54g0X+cFROGy94aDQ=
-github.com/ava-labs/libevm v1.13.15-0.20260218120213-98a792673af1/go.mod h1:oyJdZfpQTc9fVzAbDry+QRYeiCbw8s/kGaDUsEMpb4I=
+github.com/ava-labs/libevm v1.13.15-0.20260306175353-3ee189cbd80d h1:44H8MkoB2VwOYeu1WBRlbcwPHfbo2H5RNlQe013NMCg=
+github.com/ava-labs/libevm v1.13.15-0.20260306175353-3ee189cbd80d/go.mod h1:oyJdZfpQTc9fVzAbDry+QRYeiCbw8s/kGaDUsEMpb4I=
 github.com/aymerick/raymond v2.0.3-0.20180322193309-b565731e1464+incompatible/go.mod h1:osfaiScAUVup+UC9Nfq76eWqDhXlp+4UYaA8uhTBO6g=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=

--- a/saexec/execution.go
+++ b/saexec/execution.go
@@ -173,8 +173,8 @@ func (e *Executor) execute(b *blocks.Block, log logging.Logger) error {
 		// guaranteed when using the [Executor] via the public API, it's clearer
 		// to check than to require the reader to reason about dropping the
 		// flag.
-		if ch, ok := e.receipts.Load(tx.Hash()); ok {
-			ch <- &Receipt{receipt, signer, tx}
+		if r, ok := e.receipts.Load(tx.Hash()); ok {
+			r.Put(&Receipt{receipt, signer, tx})
 		}
 		receipts[ti] = receipt
 	}

--- a/saexec/receipts.go
+++ b/saexec/receipts.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/ava-labs/libevm/common"
 	"github.com/ava-labs/libevm/core/types"
+	"github.com/ava-labs/libevm/libevm/eventual"
 
 	"github.com/ava-labs/strevm/blocks"
 )
@@ -21,15 +22,15 @@ func (e *Executor) createReceiptBuffers(b *blocks.Block) {
 	for i, tx := range b.Transactions() {
 		txs[i] = tx.Hash()
 	}
-	e.receipts.StoreFromFunc(func(common.Hash) chan *Receipt {
-		return make(chan *Receipt, 1)
+	e.receipts.StoreFromFunc(func(common.Hash) eventual.Value[*Receipt] {
+		return eventual.New[*Receipt]()
 	}, txs...)
 	// This satisfies the minimum-lifespan guarantee of [Executor.RecentReceipt]
 	// but, in practice, will keep the receipts around until the block is an
 	// ancestor of the last-settled block. See [sae.VM.AcceptBlock] for details.
 	// This should adequately cover the post-tx-issuance period during which
 	// users request receipts.
-	runtime.AddCleanup(b, func(rs *syncMap[common.Hash, chan *Receipt]) {
+	runtime.AddCleanup(b, func(rs *syncMap[common.Hash, eventual.Value[*Receipt]]) {
 		rs.Delete(txs...)
 	}, e.receipts)
 }
@@ -60,24 +61,15 @@ type Receipt struct {
 // transaction, either because it hasn't been enqueued, or because it has been
 // cleared from the cache.
 //
-// The only possible error is one returned by [context.Cause] upon context
-// cancellation.
+// The only possible error is one returned by [eventual.Value.PeekCtx] upon
+// context cancellation.
 func (e *Executor) RecentReceipt(ctx context.Context, tx common.Hash) (*Receipt, bool, error) {
-	ch, ok := e.receipts.Load(tx)
+	v, ok := e.receipts.Load(tx)
 	if !ok {
 		return nil, false, nil
 	}
-	// TODO(arr4n) abstract the internal libevm/parallel `eventual` type into a
-	// separate package and use it here with `peek()`. It's semantically
-	// identical but clearer than receiving and then immediately sending a value
-	// with a single-buffered channel.
-	select {
-	case r := <-ch:
-		ch <- r
-		return r, true, nil
-	case <-ctx.Done():
-		return nil, true, context.Cause(ctx)
-	}
+	r, err := v.PeekCtx(ctx)
+	return r, true, err
 }
 
 // A syncMap holds values keyed by uniformly distributed keys, allowing for

--- a/saexec/saexec.go
+++ b/saexec/saexec.go
@@ -21,6 +21,7 @@ import (
 	"github.com/ava-labs/libevm/core/types"
 	"github.com/ava-labs/libevm/ethdb"
 	"github.com/ava-labs/libevm/event"
+	"github.com/ava-labs/libevm/libevm/eventual"
 	"github.com/ava-labs/libevm/params"
 	"github.com/ava-labs/libevm/triedb"
 
@@ -44,7 +45,7 @@ type Executor struct {
 	headEvents  event.FeedOf[core.ChainHeadEvent]
 	chainEvents event.FeedOf[core.ChainEvent]
 	logEvents   event.FeedOf[[]*types.Log]
-	receipts    *syncMap[common.Hash, chan *Receipt]
+	receipts    *syncMap[common.Hash, eventual.Value[*Receipt]]
 
 	chainContext *chainContext
 	chainConfig  *params.ChainConfig
@@ -106,7 +107,7 @@ func New(
 		stateCache:  cache,
 		snaps:       snaps,
 		xdb:         xdb,
-		receipts:    newSyncMap[common.Hash, chan *Receipt](),
+		receipts:    newSyncMap[common.Hash, eventual.Value[*Receipt]](),
 	}
 	e.lastExecuted.Store(lastExecuted)
 


### PR DESCRIPTION
The pattern of sending and receiving on a single-buffered channel[^1] was borrowed from `libevm/parallel`, but has now been abstracted. The use of an `eventual.Value` is semantically identical, but more readable as it is self-documenting.

[^1]: One of Stephen's favourite, FWIW