### PR TITLE
chore: bump Go to 1.25.8 and libevm to latest

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,13 +1,13 @@
 module github.com/ava-labs/strevm
 
-go 1.25.7
+go 1.25.8
 
 tool github.com/go-task/task/v3/cmd/task
 
 require (
 	github.com/arr4n/shed v0.0.0-20260217105731-4cd15adfa100
 	github.com/ava-labs/avalanchego v1.14.2-0.20260123184805-18c4dbe2714e
-	github.com/ava-labs/libevm v1.13.15-0.20260309162615-3d7f8934ee6c
+	github.com/ava-labs/libevm v1.13.15-0.20260310192938-d71b6cc8513a
 	github.com/google/go-cmp v0.7.0
 	github.com/holiman/uint256 v1.2.4
 	github.com/stretchr/testify v1.11.1

--- a/go.sum
+++ b/go.sum
@@ -42,8 +42,8 @@ github.com/arr4n/shed v0.0.0-20260217105731-4cd15adfa100 h1:j0Pj/Gq5XTbJEyzoSX82
 github.com/arr4n/shed v0.0.0-20260217105731-4cd15adfa100/go.mod h1:eD5UkxiWTdbkqM7mg2Xf981SAeWQ/Q80js/1rFcKpfg=
 github.com/ava-labs/avalanchego v1.14.2-0.20260123184805-18c4dbe2714e h1:vmO2RL0wG6QuMxZqSzY13BtR77XsSCcCmiwPKCJkAXI=
 github.com/ava-labs/avalanchego v1.14.2-0.20260123184805-18c4dbe2714e/go.mod h1:aE2RZUWfJwiK+tyVu+fnE5DWOZ0W1TEg5BL3n1rkq7s=
-github.com/ava-labs/libevm v1.13.15-0.20260309162615-3d7f8934ee6c h1:ONUfn7PQNVflkbexl9RFDhkSXgyIUF+VKKI4QAQUCkc=
-github.com/ava-labs/libevm v1.13.15-0.20260309162615-3d7f8934ee6c/go.mod h1:oyJdZfpQTc9fVzAbDry+QRYeiCbw8s/kGaDUsEMpb4I=
+github.com/ava-labs/libevm v1.13.15-0.20260310192938-d71b6cc8513a h1:rPtNc8GdAxiCxSdL+kaM42Lfuoxi034X4Fe20lR2auI=
+github.com/ava-labs/libevm v1.13.15-0.20260310192938-d71b6cc8513a/go.mod h1:6NxGoR1aLABnfLy+fncXRj0W6rUoUrXghnAWZ+Rhr4o=
 github.com/aymerick/raymond v2.0.3-0.20180322193309-b565731e1464+incompatible/go.mod h1:osfaiScAUVup+UC9Nfq76eWqDhXlp+4UYaA8uhTBO6g=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=


### PR DESCRIPTION
This aligns the Go version with libevm's Go version and updates the dependency to the tip of libevm's main. This is needed to bring in changes exporting the SignedTransaction type. 