### PR TITLE
refactor: prevent mutation of shared `uint256.Int` and `big.Int` values

### DIFF
--- a/blocks/execution.go
+++ b/blocks/execution.go
@@ -211,7 +211,7 @@ func executionArtefact[T any](b *Block, desc string, get func(*executionResults)
 
 func (e *executionResults) executedByGasTime() *gastime.Time    { return e.byGas.Clone() }
 func (e *executionResults) executedByWallTime() time.Time       { return e.byWall }
-func (e *executionResults) cloneBaseFee() *uint256.Int          { return e.baseFee.Clone() }
+func (e *executionResults) executedBaseFee() uint256.Int        { return e.baseFee }
 func (e *executionResults) cloneReceiptsSlice() types.Receipts  { return slices.Clone(e.receipts) }
 func (e *executionResults) postExecutionStateRoot() common.Hash { return e.stateRootPost }
 
@@ -227,10 +227,10 @@ func (b *Block) ExecutedByWallTime() time.Time {
 	return executionArtefact(b, "execution (wall) time", (*executionResults).executedByWallTime)
 }
 
-// ExecutedBaseFee returns the base gas price passed to [Block.MarkExecuted] or nil if
-// no such successful call has been made.
-func (b *Block) ExecutedBaseFee() *uint256.Int {
-	return executionArtefact(b, "baseFee", (*executionResults).cloneBaseFee)
+// ExecutedBaseFee returns the base gas price passed to [Block.MarkExecuted] or the
+// zero value if no such successful call has been made.
+func (b *Block) ExecutedBaseFee() uint256.Int {
+	return executionArtefact(b, "baseFee", (*executionResults).executedBaseFee)
 }
 
 // Receipts returns the receipts passed to [Block.MarkExecuted] or nil if no
@@ -299,6 +299,6 @@ func PostExecutionStateRoot(xdb saedb.ExecutionResults, blockNum uint64) (common
 // ExecutionBaseFee mirrors the behaviour of [Block.RestoreExecutionArtefacts],
 // without requiring a full [Block], and only returning the base fee when the
 // block was executed (as against the worst-case prediction).
-func ExecutionBaseFee(xdb saedb.ExecutionResults, blockNum uint64) (*uint256.Int, error) {
-	return persistedExecutionArtefact(xdb, blockNum, (*executionResults).cloneBaseFee)
+func ExecutionBaseFee(xdb saedb.ExecutionResults, blockNum uint64) (uint256.Int, error) {
+	return persistedExecutionArtefact(xdb, blockNum, (*executionResults).executedBaseFee)
 }

--- a/blocks/execution_test.go
+++ b/blocks/execution_test.go
@@ -149,7 +149,7 @@ func TestMarkExecuted(t *testing.T) {
 			require.NoError(t, b.WaitUntilExecuted(context.Background()), "WaitUntilExecuted()")
 
 			assert.Zero(t, b.ExecutedByGasTime().Compare(gasTime.Time), "ExecutedByGasTime().Compare([original input])")
-			assert.Zero(t, b.ExecutedBaseFee().Cmp(baseFee), "ExecutedBaseFee().Cmp([original input])")
+			assert.Equal(t, *baseFee, b.ExecutedBaseFee(), "ExecutedBaseFee()")
 			assert.Empty(t, cmp.Diff(receipts, b.Receipts(), cmputils.Receipts(), cmputils.NilSlicesAreEmpty[[]*types.Log]()), "Receipts()")
 
 			assert.Equal(t, stateRoot, b.PostExecutionStateRoot(), "PostExecutionStateRoot()") // i.e. this block

--- a/gasprice/estimator.go
+++ b/gasprice/estimator.go
@@ -303,7 +303,7 @@ func (e *Estimator) FeeHistory(
 		if len(rewardPercentiles) != 0 {
 			reward = append(reward, b.tipPercentiles(rewardPercentiles))
 		}
-		baseFee = append(baseFee, b.baseFee)
+		baseFee = append(baseFee, new(big.Int).Set(b.baseFee))
 		gasUsedRatio = append(gasUsedRatio, float64(b.gasUsed)/float64(b.gasLimit))
 	}
 	if last == lastAcceptedNumber {
@@ -311,10 +311,11 @@ func (e *Estimator) FeeHistory(
 		if bounds == nil {
 			baseFee = append(baseFee, lastAccepted.EthBlock().BaseFee())
 		} else {
-			baseFee = append(baseFee, bounds.LatestEndTime.BaseFee().ToBig())
+			bf := bounds.LatestEndTime.BaseFee()
+			baseFee = append(baseFee, bf.ToBig())
 		}
 	} else if b := e.blockCache.getBlock(last + 1); b != nil {
-		baseFee = append(baseFee, b.baseFee)
+		baseFee = append(baseFee, new(big.Int).Set(b.baseFee))
 	} else {
 		return nil, nil, nil, nil, fmt.Errorf("%w: %d", errMissingBlock, last+1)
 	}

--- a/gasprice/estimator_test.go
+++ b/gasprice/estimator_test.go
@@ -296,6 +296,8 @@ func TestFeeHistory(t *testing.T) {
 	bounds := &blocks.WorstCaseBounds{
 		LatestEndTime: gt,
 	}
+	nextBF := bounds.LatestEndTime.BaseFee()
+	nextBaseFee := nextBF.ToBig()
 	type (
 		blockSpec struct {
 			bounds *blocks.WorstCaseBounds
@@ -447,7 +449,7 @@ func TestFeeHistory(t *testing.T) {
 				height: common.Big1,
 				baseFees: []*big.Int{
 					big.NewInt(1),
-					bounds.LatestEndTime.BaseFee().ToBig(),
+					nextBaseFee,
 				},
 				portionFull: []float64{
 					21_000. / gasLimit,
@@ -506,7 +508,7 @@ func TestFeeHistory(t *testing.T) {
 				baseFees: []*big.Int{
 					big.NewInt(1),
 					big.NewInt(2),
-					bounds.LatestEndTime.BaseFee().ToBig(),
+					nextBaseFee,
 				},
 				portionFull: []float64{
 					21_000. / gasLimit,

--- a/gastime/gastime.go
+++ b/gastime/gastime.go
@@ -157,8 +157,8 @@ func (tm *Time) excessScalingFactor() gas.Gas {
 
 // BaseFee is equivalent to [Time.Price], returning the result as a uint256 for
 // compatibility with geth/libevm objects.
-func (tm *Time) BaseFee() *uint256.Int {
-	return uint256.NewInt(uint64(tm.Price()))
+func (tm *Time) BaseFee() uint256.Int {
+	return *uint256.NewInt(uint64(tm.Price()))
 }
 
 // SetRate is equivalent to [Time.SetTarget] after (integer) division of `r` by

--- a/sae/block_builder.go
+++ b/sae/block_builder.go
@@ -260,11 +260,12 @@ func (b *blockBuilderG[T]) buildWithTxs(
 	}
 
 	hdr.GasLimit = state.GasLimit()
-	hdr.BaseFee = state.BaseFee().ToBig()
+	bf := state.BaseFee()
+	hdr.BaseFee = bf.ToBig()
 
 	var (
 		candidates = pendingTxs(txpool.PendingFilter{
-			BaseFee: state.BaseFee(),
+			BaseFee: &bf,
 		})
 		included []*types.Transaction
 	)

--- a/sae/rpc/custom.go
+++ b/sae/rpc/custom.go
@@ -42,7 +42,8 @@ func (c *customAPI) estimateNextBaseFee() *big.Int {
 	if bounds == nil {
 		return c.b.LastAccepted().EthBlock().BaseFee()
 	}
-	return bounds.LatestEndTime.BaseFee().ToBig()
+	bf := bounds.LatestEndTime.BaseFee()
+	return bf.ToBig()
 }
 
 // DetailedExecutionResult is the response for eth_callDetailed.

--- a/sae/rpc/stateful.go
+++ b/sae/rpc/stateful.go
@@ -94,7 +94,8 @@ func (b *backend) StateAndHeaderByNumberOrHash(ctx context.Context, numOrHash rp
 	if bl, ok := b.ConsensusCriticalBlock(hash); ok {
 		hdr = bl.Header()
 		hdr.Root = bl.PostExecutionStateRoot()
-		hdr.BaseFee = bl.ExecutedBaseFee().ToBig()
+		bf := bl.ExecutedBaseFee()
+		hdr.BaseFee = bf.ToBig()
 	} else {
 		hdr = rawdb.ReadHeader(b.DB(), hash, num)
 

--- a/sae/rpc_custom_test.go
+++ b/sae/rpc_custom_test.go
@@ -33,7 +33,10 @@ func TestBaseFee(t *testing.T) {
 	b := sut.runConsensusLoop(t)
 	sut.testRPC(ctx, t, rpcTest{
 		method: "eth_baseFee",
-		want:   (*hexutil.Big)(b.WorstCaseBounds().LatestEndTime.BaseFee().ToBig()),
+		want: func() *hexutil.Big {
+			bf := b.WorstCaseBounds().LatestEndTime.BaseFee()
+			return (*hexutil.Big)(bf.ToBig())
+		}(),
 	})
 }
 
@@ -52,7 +55,8 @@ func TestSuggestPriceOptions(t *testing.T) {
 	// See testing of [saerpc.NewPriceOptions] for behavioral tests.
 	tip, err := sut.rawVM.GethRPCBackends().SuggestGasTipCap(t.Context())
 	require.NoErrorf(t, err, "SuggestGasTipCap()")
-	doubleBaseFee := b.WorstCaseBounds().LatestEndTime.BaseFee().ToBig()
+	nextBF := b.WorstCaseBounds().LatestEndTime.BaseFee()
+	doubleBaseFee := nextBF.ToBig()
 	doubleBaseFee.Lsh(doubleBaseFee, 1)
 	sut.testRPC(ctx, t, rpcTest{
 		method: "eth_suggestPriceOptions",

--- a/saexec/execution.go
+++ b/saexec/execution.go
@@ -175,7 +175,7 @@ func Execute(
 	}
 
 	baseFee := gasClock.BaseFee()
-	b.CheckBaseFeeBound(baseFee)
+	b.CheckBaseFeeBound(&baseFee)
 	header := types.CopyHeader(b.Header())
 	header.BaseFee = baseFee.ToBig()
 
@@ -265,7 +265,7 @@ func Execute(
 	)
 
 	r := &ExecutionResults{
-		BaseFee:  baseFee,
+		BaseFee:  &baseFee,
 		StateDB:  stateDB,
 		Signer:   signer,
 		BlockCtx: core.NewEVMBlockContext(header, chainCtx, &header.Coinbase),

--- a/saexec/saexec_test.go
+++ b/saexec/saexec_test.go
@@ -618,8 +618,9 @@ func TestGasAccounting(t *testing.T) {
 			if i > 0 {
 				wantBaseFee = steps[i-1].wantPriceAfter
 			}
-			require.Truef(t, b.ExecutedBaseFee().IsUint64(), "%T.BaseFee().IsUint64()", b)
-			assert.Equalf(t, wantBaseFee, gas.Price(b.ExecutedBaseFee().Uint64()), "%T.BaseFee().Uint64()", b)
+			gotBF := b.ExecutedBaseFee()
+			require.Truef(t, gotBF.IsUint64(), "%T.BaseFee().IsUint64()", b)
+			assert.Equalf(t, wantBaseFee, gas.Price(gotBF.Uint64()), "%T.BaseFee().Uint64()", b)
 
 			t.Run("EffectiveGasPrice", func(t *testing.T) {
 				want := uint256.NewInt(uint64(wantBaseFee) + step.gasTipCap)

--- a/worstcase/state.go
+++ b/worstcase/state.go
@@ -129,7 +129,8 @@ func (s *State) StartBlock(h *types.Header) error {
 		return fmt.Errorf("%w: current size %d exceeds maximum size for accepting new blocks %d", ErrQueueFull, s.qSize, maxOpenQSize)
 	}
 
-	s.baseFee = s.clock.BaseFee()
+	bf := s.clock.BaseFee()
+	s.baseFee = &bf
 	clear(s.minOpBurnerBalances) // [State.FinishBlock] returns a clone so we can reuse the alloc here
 	s.minOpBurnerBalances = s.minOpBurnerBalances[:0]
 
@@ -166,8 +167,8 @@ func (s *State) GasLimit() uint64 {
 }
 
 // BaseFee returns the worst-case base fee for the current block.
-func (s *State) BaseFee() *uint256.Int {
-	return s.baseFee
+func (s *State) BaseFee() uint256.Int {
+	return *s.baseFee
 }
 
 var errCostOverflow = errors.New("Cost() overflows uint256")

--- a/worstcase/state_test.go
+++ b/worstcase/state_test.go
@@ -119,7 +119,7 @@ func TestMultipleBlocks(t *testing.T) {
 		hooks                 *hookstest.Stub
 		time                  uint64
 		wantGasLimit          uint64
-		wantBaseFee           *uint256.Int
+		wantBaseFee           uint256.Int
 		ops                   []op
 		txsAfterOps           []*types.Transaction
 		wantMinSenderBalances []map[common.Address]uint64 // transformed to uint256.Int
@@ -127,7 +127,7 @@ func TestMultipleBlocks(t *testing.T) {
 		{
 			hooks:        hookstest.NewStub(2 * initialGasTarget), // Will double the target _after_ this block.
 			wantGasLimit: initialMaxBlockSize,
-			wantBaseFee:  uint256.NewInt(1),
+			wantBaseFee:  *uint256.NewInt(1),
 			ops: []op{
 				{
 					name: "include_small_operation",
@@ -166,7 +166,7 @@ func TestMultipleBlocks(t *testing.T) {
 		{
 			hooks:        hookstest.NewStub(initialGasTarget), // Restore the target _after_ this block.
 			wantGasLimit: 2 * initialMaxBlockSize,
-			wantBaseFee:  uint256.NewInt(2),
+			wantBaseFee:  *uint256.NewInt(2),
 			ops: []op{
 				{
 					name: "import",
@@ -216,7 +216,7 @@ func TestMultipleBlocks(t *testing.T) {
 		},
 		{
 			wantGasLimit: initialMaxBlockSize,
-			wantBaseFee:  uint256.NewInt(2),
+			wantBaseFee:  *uint256.NewInt(2),
 			txsAfterOps: []*types.Transaction{
 				wallet.SetNonceAndSign(t, 0, &types.LegacyTx{
 					To:       &common.Address{},
@@ -264,7 +264,7 @@ func TestMultipleBlocks(t *testing.T) {
 			// fee.
 			time:         21,
 			wantGasLimit: initialMaxBlockSize,
-			wantBaseFee:  uint256.NewInt(1),
+			wantBaseFee:  *uint256.NewInt(1),
 		},
 	}
 	for i, block := range tests {
@@ -295,7 +295,7 @@ func TestMultipleBlocks(t *testing.T) {
 		require.NoError(t, wantLatestEndTime.AfterBlock(gas.Gas(state.GasUsed()), sut.hooks, header), "AfterBlock()")
 
 		want := &blocks.WorstCaseBounds{
-			MaxBaseFee:    block.wantBaseFee,
+			MaxBaseFee:    &block.wantBaseFee,
 			LatestEndTime: wantLatestEndTime.Clone(),
 		}
 		for _, bals := range block.wantMinSenderBalances {


### PR DESCRIPTION
This PR has to fixes to prevent @ARR4N's concern/FYI about returning pointers to big ints as they can be mutated by the caller, which corrupts them for everyone. 

1. `uint256.Int`: use value types instead of pointers. I also learned that the underlying representation of a uint256.Int is `[4]uint64`. 
2. `*big.Int`: clone at return boundaries to make mutation harmless. 

Note that for a nil check, `blocks.Block.BaseFee()` previously returned `nil` when the block hadn't been executed. It now returns the zero value `uint256.Int{}`. It doesn't appear that any caller relied on `nil` to distinguish `"not executed"` from "base fee is zero", as we have `Block.Executed()`. 

I did not change `txgossip/priority.go` as all the `*uint256.Ints` come from the external `txpool` API or `sae.uint256FromBig()` which returns `*uint256.Int` to set `txpool.LazyTransaction` fields -- if anyone has any thoughts on these I am open! 