### PR TITLE
Export Peers and ValidatorPeers

### DIFF
--- a/sae/rpc.go
+++ b/sae/rpc.go
@@ -76,7 +76,7 @@ func (vm *VM) ethRPCServer() (*rpc.Server, error) {
 		// - net_listening
 		// - net_peerCount
 		// - net_version
-		{"net", newNetAPI(vm.peers, vm.exec.ChainConfig().ChainID.Uint64())},
+		{"net", newNetAPI(vm.Peers, vm.exec.ChainConfig().ChainID.Uint64())},
 		// Geth-specific APIs:
 		// - txpool_content
 		// - txpool_contentFrom

--- a/sae/vm.go
+++ b/sae/vm.go
@@ -49,7 +49,8 @@ import (
 // provide a last-synchronous block, which MAY be the genesis.
 type VM struct {
 	*p2p.Network
-	peers *p2p.Peers
+	Peers          *p2p.Peers
+	ValidatorPeers *p2p.Validators
 
 	hooks   hook.Points
 	config  Config
@@ -299,7 +300,8 @@ func NewVM[T hook.Transaction](
 		}()
 
 		vm.Network = network
-		vm.peers = peers
+		vm.Peers = peers
+		vm.ValidatorPeers = validatorPeers
 		vm.mempool.RegisterPushGossiper(pushGossiper)
 		vm.toClose = append(vm.toClose, closerFunc(func() error {
 			cancel()


### PR DESCRIPTION
In coreth, we need to register our own p2p gossip system for the atomic txs. This system will use the same `p2p.Network`, so they should also reuse the `Peers` and `ValidatorPeers` values.