### PR TITLE
test(sae): add more test cases

### DIFF
--- a/sae/rpc_test.go
+++ b/sae/rpc_test.go
@@ -902,17 +902,17 @@ func TestGetReceipts(t *testing.T) {
 			wantRaw: rawReceiptsFrom(unsettled),
 		},
 		{
-			id:      rpc.BlockNumberOrHashWithNumber(rpc.BlockNumber(onDisk.Height())),
+			id:      rpc.BlockNumberOrHashWithNumber(rpc.BlockNumber(onDisk.Height())), //nolint:gosec // Test block heights won't overflow
 			want:    wantOnDisk,
 			wantRaw: rawReceiptsFrom(onDisk),
 		},
 		{
-			id:      rpc.BlockNumberOrHashWithNumber(rpc.BlockNumber(settled.Height())),
+			id:      rpc.BlockNumberOrHashWithNumber(rpc.BlockNumber(settled.Height())), //nolint:gosec // Test block heights won't overflow
 			want:    wantSettled,
 			wantRaw: rawReceiptsFrom(settled),
 		},
 		{
-			id:      rpc.BlockNumberOrHashWithNumber(rpc.BlockNumber(unsettled.Height())),
+			id:      rpc.BlockNumberOrHashWithNumber(rpc.BlockNumber(unsettled.Height())), //nolint:gosec // Test block heights won't overflow
 			want:    wantUnsettled,
 			wantRaw: rawReceiptsFrom(unsettled),
 		},


### PR DESCRIPTION
In `TestGetReceipts` - new entries in the test table covering previously untested lookup paths:
- `debug_getRawReceipts` (and `eth_getBlockReceipts`) by explicit block number for on-disk, settled, and unsettled blocks - previously only tested by hash.
- `debug_getRawReceipts` (and `eth_getBlockReceipts`) for `SafeBlockNumber` and `FinalizedBlockNumber` - previously only `LatestBlockNumber` was covered.

Signed-off-by: Tsvetan Dimitrov (tsvetan.dimitrov@avalabs.org)