### PR TITLE
chore(rpc): add batch limit

### DIFF
--- a/sae/rpc/server.go
+++ b/sae/rpc/server.go
@@ -11,11 +11,9 @@ import (
 	"github.com/ava-labs/libevm/libevm/debug"
 	"github.com/ava-labs/libevm/libevm/ethapi"
 	"github.com/ava-labs/libevm/rpc"
-
-	_ "github.com/ava-labs/libevm/node"
 )
 
-// Taken as the defaults in [node.DefaultConfig]
+// Taken as the defaults from geth / libevm's `node.DefaultConfig`.
 const (
 	batchLimit           = 1000
 	batchResponseMaxSize = 25 * 1000 * 1000 // 25 MB


### PR DESCRIPTION
The RPC server allows batching, which by default, has no size limit. Our infrastructure never overrides these defaults, so unless we actually NEED to have a config for this, it felt simpler not to.