### PR TITLE
fix: make EnableLibEVMTBLogger safe for parallel fuzz sub-tests

### DIFF
--- a/saetest/logging.go
+++ b/saetest/logging.go
@@ -5,6 +5,7 @@ package saetest
 
 import (
 	"context"
+	"os"
 	"runtime"
 	"slices"
 	"sync/atomic"
@@ -169,18 +170,11 @@ func (l *TBLogger) log(lvl logging.Level, msg string, fields ...zap.Field) {
 	to("[Log@%s] %s %v - %s:%d", lvl, msg, enc.Fields, file, line)
 }
 
-// libevmLogConfigured ensures only the first [EnableLibEVMTBLogger] call
-// sets the global logger. Reset in `tb` cleanup.
+// libevmLogConfigured ensures only the first call to set the global libevm
+// logger takes effect. Reset in `tb` cleanup.
 var libevmLogConfigured atomic.Bool
 
-// EnableLibEVMTBLogger redirects all libevm logs to tb. Logs at error level
-// and above are treated as test failures. The original logger is restored
-// during `tb` cleanup.
-//
-// Safe to call from parallel tests - only the first call takes effect. For
-// fuzz tests, call with the parent [*testing.F] before [testing.F.Fuzz] so
-// parallel sub-tests' calls are no-ops.
-func EnableLibEVMTBLogger(tb testing.TB) {
+func setLibEVMLogger(tb testing.TB, handler slog.Handler) {
 	tb.Helper()
 	if !libevmLogConfigured.CompareAndSwap(false, true) {
 		return
@@ -190,5 +184,24 @@ func EnableLibEVMTBLogger(tb testing.TB) {
 		log.SetDefault(old)
 		libevmLogConfigured.Store(false)
 	})
-	log.SetDefault(log.NewLogger(ethtest.NewTBLogHandler(tb, slog.LevelError)))
+	log.SetDefault(log.NewLogger(handler))
+}
+
+// EnableLibEVMTBLogger redirects all libevm logs to tb. Logs at error level
+// and above are treated as test failures. The original logger is restored
+// during `tb` cleanup.
+//
+// Safe to call from parallel tests - only the first call takes effect.
+func EnableLibEVMTBLogger(tb testing.TB) {
+	tb.Helper()
+	setLibEVMLogger(tb, ethtest.NewTBLogHandler(tb, slog.LevelError))
+}
+
+// EnableLibEVMTerminalLogger sets the global libevm logger to write errors
+// to stderr. Use before [testing.F.Fuzz] so parallel sub-tests' calls to
+// [EnableLibEVMTBLogger] are no-ops (Go forbids [testing.F.Logf] inside
+// fuzz targets).
+func EnableLibEVMTerminalLogger(tb testing.TB) {
+	tb.Helper()
+	setLibEVMLogger(tb, log.NewTerminalHandlerWithLevel(os.Stderr, log.LevelError, true))
 }

--- a/saexec/saexec_test.go
+++ b/saexec/saexec_test.go
@@ -640,7 +640,7 @@ func FuzzOpCodes(f *testing.F) {
 	// Although it's tempting to run multiple `code` slices in a block, to
 	// amortise the fixed setup cost of the SUT, this stops the Go fuzzer from
 	// knowing about their independence, resulting in a lot of empty inputs.
-	saetest.EnableLibEVMTBLogger(f)
+	saetest.EnableLibEVMTerminalLogger(f)
 
 	f.Fuzz(func(t *testing.T, code []byte) {
 		t.Parallel() // for corpus in ./testdata/


### PR DESCRIPTION
- Guard `log.SetDefault` with an `atomic.Bool` so only the first call takes effect. This removes the need for the `withoutGlobalLogger` option machinery in `newSUT` while preventing data races from parallel fuzz
sub-tests each calling `EnableLibEVMTBLogger` via `newSUT`.
- `FuzzOpCodes` now calls `EnableLibEVMTerminalLogger(f)` before `f.Fuzz()` since Go forbids `testing.F.Logf` inside fuzz targets. Sub-tests' calls to `EnableLibEVMTBLogger` are no-ops.


Signed-off-by: Tsvetan Dimitrov (tsvetan.dimitrov@avalabs.org)