### PR TITLE
Log preimage when block verification fails

### DIFF
--- a/sae/block_builder.go
+++ b/sae/block_builder.go
@@ -183,6 +183,7 @@ func (b *blockBuilderG[T]) buildWithTxs(
 	log = log.With(
 		zap.Uint64("last_settled_height", lastSettled.Height()),
 		zap.Stringer("last_settled_hash", lastSettled.Hash()),
+		zap.Stringer("last_settled_gas_time", lastSettled.ExecutedByGasTime()),
 	)
 
 	state, err := worstcase.NewState(b.hooks, b.exec.ChainConfig(), lastSettled, b.exec)

--- a/sae/blocks.go
+++ b/sae/blocks.go
@@ -18,6 +18,7 @@ import (
 	"github.com/ava-labs/libevm/core/types"
 	"github.com/ava-labs/libevm/ethdb"
 	"github.com/ava-labs/libevm/rlp"
+	"go.uber.org/zap"
 
 	"github.com/ava-labs/strevm/blocks"
 	saetypes "github.com/ava-labs/strevm/types"
@@ -90,6 +91,10 @@ func (vm *VM) VerifyBlock(ctx context.Context, bCtx *block.Context, b *blocks.Bl
 	// key to the purpose of this method so included here to be defensive. It
 	// also provides a clearer failure message.
 	if reH, verH := rebuilt.Hash(), b.Hash(); reH != verH {
+		vm.log().Debug("block verification failed",
+			zap.Reflect("block", b.Header()),
+			zap.Reflect("rebuilt", rebuilt.Header()),
+		)
 		return fmt.Errorf("%w; rebuilt as %#x when verifying %#x", errHashMismatch, reH, verH)
 	}
 	if err := b.CopyAncestorsFrom(rebuilt); err != nil {


### PR DESCRIPTION
This PR adds some trivial logging that is required to properly investigate block verification failures.

We could alternatively include the header json in the error, but I think that is needlessly expensive during the normal case.