### PR TITLE
Allow `hook.BlockBuilder.BuildHeader` to error

### DIFF
--- a/blocks/time_test.go
+++ b/blocks/time_test.go
@@ -38,7 +38,8 @@ func TestGasTime(t *testing.T) {
 	parent := &types.Header{
 		Number: big.NewInt(1),
 	}
-	hdr := hooks.BuildHeader(parent)
+	hdr, err := hooks.BuildHeader(parent)
+	require.NoErrorf(t, err, "%T.BuildHeader()", hooks)
 
 	got := GasTime(hooks, hdr, parent)
 	want := proxytime.New(unix, rate)
@@ -72,7 +73,8 @@ func FuzzTimeExtraction(f *testing.F) {
 		parent := &types.Header{
 			Number: big.NewInt(1),
 		}
-		hdr := hooks.BuildHeader(parent)
+		hdr, err := hooks.BuildHeader(parent)
+		require.NoErrorf(t, err, "%T.BuildHeader()", hooks)
 
 		t.Run("PreciseTime", func(t *testing.T) {
 			got := PreciseTime(hooks, hdr)

--- a/hook/hook.go
+++ b/hook/hook.go
@@ -88,7 +88,7 @@ type BlockBuilder[T Transaction] interface {
 	//
 	// SAE always uses this method instead of directly constructing a header, to
 	// ensure any libevm header extras are properly populated.
-	BuildHeader(parent *types.Header) *types.Header
+	BuildHeader(parent *types.Header) (*types.Header, error)
 	// PotentialEndOfBlockOps returns an iterator of custom transactions that
 	// would be valid to include into a block.
 	//

--- a/hook/hookstest/stub.go
+++ b/hook/hookstest/stub.go
@@ -100,7 +100,7 @@ func (s *Stub) ExecutionResultsDB(dataDir string) (saedb.ExecutionResults, error
 // BuildHeader constructs a header that builds on top of the parent header. The
 // `Extra` field SHOULD NOT be modified as it encodes the sub-second block time
 // and end-of-block ops.
-func (s *Stub) BuildHeader(parent *types.Header) *types.Header {
+func (s *Stub) BuildHeader(parent *types.Header) (*types.Header, error) {
 	var now time.Time
 	if s.Now != nil {
 		now = s.Now()
@@ -117,7 +117,7 @@ func (s *Stub) BuildHeader(parent *types.Header) *types.Header {
 		Time:       uint64(now.Unix()), //nolint:gosec // Known non-negative
 		Extra:      e.MarshalCanoto(),
 	}
-	return hdr
+	return hdr, nil
 }
 
 // PotentialEndOfBlockOps ignores its arguments and returns [Stub.Ops] as a

--- a/sae/block_builder.go
+++ b/sae/block_builder.go
@@ -138,7 +138,11 @@ func (b *blockBuilderG[T]) buildWithTxs(
 	pendingTxs func(txpool.PendingFilter) []*txgossip.LazyTransaction,
 	builder hook.BlockBuilder[T],
 ) (*blocks.Block, error) {
-	hdr := builder.BuildHeader(parent.Header())
+	hdr, err := builder.BuildHeader(parent.Header())
+	if err != nil {
+		return nil, err
+	}
+
 	log := b.log.With(
 		zap.Uint64("parent_height", parent.Height()),
 		zap.Stringer("parent_hash", parent.Hash()),


### PR DESCRIPTION
In coreth + subnet-evm, we want to enforce a minimum block time. The minimum block time is calculated based on the time of the parent block (from the provided parent header) and the time in the header being returned.

We can't put this logic in `BuildBlock` as we don't have the parent header there. (also it wouldn't make sense imo)