### PR TITLE
refactor: unexport `saedb` helpers

### DIFF
--- a/sae/recovery_test.go
+++ b/sae/recovery_test.go
@@ -196,20 +196,16 @@ func TestRecoverSimple(t *testing.T) {
 			// where the settled state was written to disk.
 			t.Run("unavailable_outside_window", func(t *testing.T) {
 				lastSettled := sut.rawVM.last.settled.Load().NumberU64()
-				committedHeight := saedb.LastCommittedTrieDBHeight(lastSettled)
+				// height at which the settled state was committed
+				committedHeight := saedb.CommitTrieDBEvery * (lastSettled / saedb.CommitTrieDBEvery) // round down to [saedb.CommitTrieDBEvery] interval
 				lastOnDisk, err := canonicalBlock(sut.rawVM.db, committedHeight)
 				require.NoErrorf(t, err, "canonicalBlock(): %d", committedHeight)
 
 				for i := sut.hooks.SettledHeight(lastOnDisk.Header()) + 1; i < lastSettled; i++ {
-					ethB, err := canonicalBlock(sut.rawVM.db, i)
-					require.NoErrorf(t, err, "canonicalBlock(%d)", i)
-					b, err := blocks.New(ethB, nil, nil, sut.logger)
-					require.NoErrorf(t, err, "blocks.New(): height %d", ethB.NumberU64())
-					require.NoErrorf(t, b.RestoreExecutionArtefacts(sut.rawVM.db, sut.rawVM.xdb, sut.rawVM.exec.ChainConfig()), "%T.RestoreExecutionArtifacts(): %d", b, b.NumberU64())
-
 					// If these states were available they would eventually
 					// result in an OOM as the triedb leaked memory.
-					root := b.PostExecutionStateRoot()
+					root, err := blocks.PostExecutionStateRoot(sut.rawVM.xdb, i)
+					require.NoErrorf(t, err, "blocks.PostExecutionStateRoot(%d)", i)
 					_, err = sut.rawVM.exec.StateDB(root)
 					want := testerr.As(func(got *trie.MissingNodeError) string {
 						if got.NodeHash != root {
@@ -218,7 +214,7 @@ func TestRecoverSimple(t *testing.T) {
 						return ""
 					})
 					if diff := testerr.Diff(err, want); diff != "" {
-						t.Errorf("%T.StateDB([post-execution root of block %d]) %s", sut.rawVM.exec, b.NumberU64(), diff)
+						t.Errorf("%T.StateDB([post-execution root of block %d]) %s", sut.rawVM.exec, i, diff)
 					}
 				}
 			})

--- a/saedb/saedb.go
+++ b/saedb/saedb.go
@@ -20,14 +20,14 @@ const (
 	commitTrieDBMask      = CommitTrieDBEvery - 1
 )
 
-// ShouldCommitTrieDB returns whether or not to commit the state trie to disk.
-func ShouldCommitTrieDB(blockNum uint64) bool {
+// shouldCommitSettled returns whether or not to commit the state trie to disk.
+func shouldCommitSettled(blockNum uint64) bool {
 	return blockNum&commitTrieDBMask == 0
 }
 
-// LastCommittedTrieDBHeight returns the largest value <= the argument at which
-// [ShouldCommitTrieDB] would have returned true.
-func LastCommittedTrieDBHeight(atOrBefore uint64) uint64 {
+// lastCommittedSettledHeight returns the largest value <= the argument at which
+// [shouldCommitTrieDB] would have returned true.
+func lastCommittedSettledHeight(atOrBefore uint64) uint64 {
 	return atOrBefore &^ commitTrieDBMask
 }
 

--- a/saedb/saedb_test.go
+++ b/saedb/saedb_test.go
@@ -18,7 +18,7 @@ func TestTrieDBCommitHeights(t *testing.T) {
 		2 * e:   true,
 		2*e + 1: false,
 	} {
-		if got := ShouldCommitTrieDB(num); got != want {
+		if got := shouldCommitSettled(num); got != want {
 			t.Errorf("CommitTrieDB(%d) got %t want %t", num, got, want)
 		}
 	}
@@ -33,17 +33,17 @@ func TestTrieDBCommitHeights(t *testing.T) {
 		2*e + 1: 2 * e,
 		3*e - 1: 2 * e,
 	} {
-		if got := LastCommittedTrieDBHeight(num); got != want {
+		if got := lastCommittedSettledHeight(num); got != want {
 			t.Errorf("LastCommitedTrieDBHeight(%d) got %d; want %d", num, got, want)
 		}
 	}
 
 	var last uint64
 	for num := range uint64(20 * e) {
-		if ShouldCommitTrieDB(num) {
+		if shouldCommitSettled(num) {
 			last = num
 		}
-		if got, want := LastCommittedTrieDBHeight(num), last; got != want {
+		if got, want := lastCommittedSettledHeight(num), last; got != want {
 			t.Errorf("LastCommitedTrieDBHeight(%d) got %d; want %d", num, got, want)
 		}
 	}

--- a/saedb/tracker.go
+++ b/saedb/tracker.go
@@ -68,7 +68,7 @@ func NewTracker(db ethdb.Database, c Config, lastExecuted common.Hash, log loggi
 }
 
 // Track tracks the root and may commit the trie associated with the root
-// to the database if [ShouldCommitTrieDB] returns true, or the [Config]
+// to the database if [shouldCommitTrieDB] returns true, or the [Config]
 // specifies that the node is archival.
 //
 // This state will be available in memory until [Tracker.Untrack] has been
@@ -88,7 +88,7 @@ func (t *Tracker) Track(root common.Hash) {
 // following priorities:
 //
 // 1. If [Config.Archival] is true, then `executionRoot` will be committed.
-// 2. If [ShouldCommitTrieDB] based on `height`, `settledRoot` is committed.
+// 2. Every [CommitTrieDBEvery] blocks, `settledRoot` is committed.
 // 3. Otherwise, nothing is committed.
 //
 // This does NOT change in-memory tracking.
@@ -101,7 +101,7 @@ func (t *Tracker) MaybeCommit(settledRoot, executionRoot common.Hash, height uin
 	case t.isArchival:
 		commit = executionRoot
 		because = "post-execution archive"
-	case ShouldCommitTrieDB(height):
+	case shouldCommitSettled(height):
 		commit = settledRoot
 		because = "settled"
 	default:
@@ -127,7 +127,7 @@ func LastHeightWithExecutionRootCommitted(db ethdb.Database, c Config, hooks hoo
 		return head
 
 	default:
-		num := LastCommittedTrieDBHeight(head)
+		num := lastCommittedSettledHeight(head)
 		if num <= lastSynchronous {
 			return lastSynchronous
 		}

--- a/saexec/saexec_test.go
+++ b/saexec/saexec_test.go
@@ -959,7 +959,7 @@ func TestStateRootAvailability(t *testing.T) {
 
 			var want testerr.Want
 			switch {
-			case saedb.ShouldCommitTrieDB(b.NumberU64()):
+			case sut.hooks.SettledHeight(b.Header())%saedb.CommitTrieDBEvery == 0:
 				// on disk
 			case expectReferenced(b.NumberU64()):
 				// still referenced


### PR DESCRIPTION
There's a few functions that are exported, but were only used in testing. They can be unexported