### PR TITLE
refactor(gastime): remove hooks import

### DIFF
--- a/blocks/execution_test.go
+++ b/blocks/execution_test.go
@@ -25,7 +25,6 @@ import (
 
 	"github.com/ava-labs/strevm/cmputils"
 	"github.com/ava-labs/strevm/gastime"
-	"github.com/ava-labs/strevm/hook"
 	"github.com/ava-labs/strevm/saetest"
 	saetypes "github.com/ava-labs/strevm/types"
 )
@@ -195,7 +194,7 @@ type selfAsHasher common.Hash
 
 func (h selfAsHasher) Hash() common.Hash { return common.Hash(h) }
 
-func mustNewGasTime(tb testing.TB, at time.Time, target, excess gas.Gas, gasPriceConfig hook.GasPriceConfig) *gastime.Time {
+func mustNewGasTime(tb testing.TB, at time.Time, target, excess gas.Gas, gasPriceConfig saetypes.GasPriceConfig) *gastime.Time {
 	tb.Helper()
 	tm, err := gastime.New(at, target, excess, gasPriceConfig)
 	require.NoError(tb, err, "gastime.New()")

--- a/blocks/time.go
+++ b/blocks/time.go
@@ -34,6 +34,6 @@ func GasTime(hooks hook.Points, hdr, parent *types.Header) *proxytime.Time[gas.G
 	target, _ := hooks.GasConfigAfter(parent)
 	rate := gastime.SafeRateOfTarget(target)
 	tm := proxytime.New(hdr.Time, rate)
-	tm.Tick(gastime.SubSecond(hooks, hdr, rate))
+	tm.Tick(gastime.SubSecond(hooks.SubSecondBlockTime(hdr), rate))
 	return tm
 }

--- a/gastime/acp176.go
+++ b/gastime/acp176.go
@@ -14,7 +14,7 @@ import (
 )
 
 // BeforeBlock is intended to be called before processing a block, with the
-// timestamp portions provided.
+// timestamp portions provided. `subSec` must be in [0, second).
 func (tm *Time) BeforeBlock(sec uint64, subSec time.Duration) { //nolint:staticcheck // subSec intentionally communicates that the value is < time.Second
 	tm.FastForwardTo(
 		sec,

--- a/gastime/acp176.go
+++ b/gastime/acp176.go
@@ -6,27 +6,26 @@ package gastime
 import (
 	"fmt"
 	"math"
+	"time"
 
 	"github.com/ava-labs/avalanchego/vms/components/gas"
-	"github.com/ava-labs/libevm/core/types"
 
-	"github.com/ava-labs/strevm/hook"
+	saetypes "github.com/ava-labs/strevm/types"
 )
 
 // BeforeBlock is intended to be called before processing a block, with the
-// timestamp sourced from [hook.Points] and [types.Header].
-func (tm *Time) BeforeBlock(hooks hook.Points, h *types.Header) {
+// timestamp portions provided.
+func (tm *Time) BeforeBlock(sec uint64, subSec time.Duration) { //nolint:staticcheck // subSec intentionally communicates that the value is < time.Second
 	tm.FastForwardTo(
-		h.Time,
-		SubSecond(hooks, h, tm.Rate()),
+		sec,
+		SubSecond(subSec, tm.Rate()),
 	)
 }
 
 // AfterBlock is intended to be called after processing a block, with the
-// target and gas configuration sourced from [hook.Points] and [types.Header].
-func (tm *Time) AfterBlock(used gas.Gas, hooks hook.Points, h *types.Header) error {
+// target and gas configuration provided.
+func (tm *Time) AfterBlock(used gas.Gas, target gas.Gas, hookCfg saetypes.GasPriceConfig) error {
 	tm.Tick(used)
-	target, hookCfg := hooks.GasConfigAfter(h)
 	// Although [Time.SetTarget] scales the excess by the same factor as the
 	// change in target, it rounds when necessary, which might alter the price
 	// by a negligible amount. We therefore take a price snapshot beforehand

--- a/gastime/acp176_test.go
+++ b/gastime/acp176_test.go
@@ -17,8 +17,8 @@ import (
 	"golang.org/x/text/language"
 	"golang.org/x/text/message"
 
-	"github.com/ava-labs/strevm/hook"
 	"github.com/ava-labs/strevm/hook/hookstest"
+	saetypes "github.com/ava-labs/strevm/types"
 )
 
 // TestInvalidConfigRejected verifies that zero values for TargetToExcessScaling
@@ -29,17 +29,17 @@ func TestInvalidConfigRejected(t *testing.T) {
 
 	tests := []struct {
 		name     string
-		config   hook.GasPriceConfig
+		config   saetypes.GasPriceConfig
 		expected error
 	}{
 		{
 			"zero_scaling",
-			hook.GasPriceConfig{TargetToExcessScaling: 0, MinPrice: DefaultGasPriceConfig().MinPrice},
+			saetypes.GasPriceConfig{TargetToExcessScaling: 0, MinPrice: DefaultGasPriceConfig().MinPrice},
 			errInvalidGasPriceConfig,
 		},
 		{
 			"zero_min_price",
-			hook.GasPriceConfig{TargetToExcessScaling: DefaultGasPriceConfig().TargetToExcessScaling, MinPrice: 0},
+			saetypes.GasPriceConfig{TargetToExcessScaling: DefaultGasPriceConfig().TargetToExcessScaling, MinPrice: 0},
 			errInvalidGasPriceConfig,
 		},
 	}
@@ -339,7 +339,7 @@ func FuzzPriceInvarianceAfterBlock(f *testing.F) {
 			t.Skip("New target too low")
 		}
 
-		initConfig := hook.GasPriceConfig{
+		initConfig := saetypes.GasPriceConfig{
 			TargetToExcessScaling: gas.Gas(initScaling),
 			MinPrice:              gas.Price(initMinPrice),
 			StaticPricing:         initStaticPricing,
@@ -368,7 +368,7 @@ func FuzzPriceInvarianceAfterBlock(f *testing.F) {
 		{
 			hooks := hookstest.NewStub(
 				gas.Gas(newTarget),
-				hookstest.WithGasPriceConfig(hook.GasPriceConfig{
+				hookstest.WithGasPriceConfig(saetypes.GasPriceConfig{
 					MinPrice:              gas.Price(newMinPrice),
 					TargetToExcessScaling: gas.Gas(newScaling),
 					StaticPricing:         newStaticPricing,
@@ -441,8 +441,8 @@ func FuzzPriceInvarianceAfterBlock(f *testing.F) {
 }
 
 // equalHookConfig is equivalent to [config.equal] but accepts a
-// [hook.GasPriceConfig] that is first converted and validated.
-func (c *config) equalHookConfig(tb testing.TB, hookCfg hook.GasPriceConfig) bool {
+// [saetypes.GasPriceConfig] that is first converted and validated.
+func (c *config) equalHookConfig(tb testing.TB, hookCfg saetypes.GasPriceConfig) bool {
 	tb.Helper()
 	other, err := newConfig(hookCfg)
 	require.NoError(tb, err)

--- a/gastime/acp176_test.go
+++ b/gastime/acp176_test.go
@@ -10,14 +10,12 @@ import (
 	"time"
 
 	"github.com/ava-labs/avalanchego/vms/components/gas"
-	"github.com/ava-labs/libevm/core/types"
 	"github.com/ava-labs/libevm/params"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/text/language"
 	"golang.org/x/text/message"
 
-	"github.com/ava-labs/strevm/hook/hookstest"
 	saetypes "github.com/ava-labs/strevm/types"
 )
 
@@ -50,8 +48,7 @@ func TestInvalidConfigRejected(t *testing.T) {
 
 			initialScaling := tm.config.targetToExcessScaling
 			initialMinPrice := tm.config.minPrice
-			hooks := hookstest.NewStub(target, hookstest.WithGasPriceConfig(tt.config))
-			err := tm.AfterBlock(0, hooks, &types.Header{Time: 42})
+			err := tm.AfterBlock(0, target, tt.config)
 			require.ErrorIs(t, err, tt.expected, "AfterBlock()")
 
 			// Config unchanged after rejected update
@@ -76,13 +73,9 @@ func TestTargetUpdateTiming(t *testing.T) {
 		newTime   uint64 = initialTime + 1
 		newTarget        = initialTarget + 100_000
 	)
-	hook := hookstest.NewStub(newTarget)
-	header := &types.Header{
-		Time: newTime,
-	}
 
 	initialPrice := tm.Price()
-	tm.BeforeBlock(hook, header)
+	tm.BeforeBlock(newTime, 0)
 	assert.Equal(t, newTime, tm.Unix(), "Unix time advanced by BeforeBlock()")
 	assert.Equal(t, initialTarget, tm.Target(), "Target not changed by BeforeBlock()")
 	// While the price technically could remain the same, being more strict
@@ -98,7 +91,7 @@ func TestTargetUpdateTiming(t *testing.T) {
 		expectedEndTime  = newTime + secondsOfGasUsed
 	)
 	used := initialRate * secondsOfGasUsed
-	require.NoError(t, tm.AfterBlock(used, hook, header), "AfterBlock()")
+	require.NoError(t, tm.AfterBlock(used, newTarget, DefaultGasPriceConfig()), "AfterBlock()")
 	assert.Equal(t, expectedEndTime, tm.Unix(), "Unix time advanced by AfterBlock() due to gas consumption")
 	assert.Equal(t, newTarget, tm.Target(), "Target updated by AfterBlock()")
 	// While the price technically could remain the same, being more strict
@@ -116,6 +109,7 @@ func FuzzWorstCasePrice(f *testing.F) {
 		time3, nanos3, used3, limit3, target3 uint64,
 	) {
 		initTarget = max(initTarget, 1)
+		gasCfg := DefaultGasPriceConfig()
 
 		initUnix := int64(min(initTimestamp, math.MaxInt64)) //nolint:gosec // I can't believe I have to be explicit about this!
 		worstcase := mustNew(t, time.Unix(initUnix, 0), gas.Gas(initTarget), gas.Gas(initExcess), DefaultGasPriceConfig())
@@ -161,24 +155,14 @@ func FuzzWorstCasePrice(f *testing.F) {
 			block.limit = max(block.used, block.limit)
 			block.target = clampTarget(max(block.target, 1))
 
-			header := &types.Header{
-				Time: block.time,
-			}
-			hook := hookstest.NewStub(block.target, hookstest.WithNow(func() time.Time {
-				return time.Unix(
-					int64(block.time), //nolint:gosec // Won't overflow for a few millennia
-					int64(block.nanos),
-				)
-			}))
-
-			worstcase.BeforeBlock(hook, header)
-			actual.BeforeBlock(hook, header)
+			worstcase.BeforeBlock(block.time, block.nanos)
+			actual.BeforeBlock(block.time, block.nanos)
 
 			// The crux of this test lies in the maintaining of this inequality
 			// through the use of `limit` instead of `used` in `AfterBlock()`
 			require.LessOrEqualf(t, actual.Price(), worstcase.Price(), "actual <= worst-case %T.Price()", actual)
-			require.NoError(t, worstcase.AfterBlock(block.limit, hook, header), "worstcase.AfterBlock()")
-			require.NoError(t, actual.AfterBlock(block.used, hook, header), "actual.AfterBlock()")
+			require.NoError(t, worstcase.AfterBlock(block.limit, block.target, gasCfg), "worstcase.AfterBlock()")
+			require.NoError(t, actual.AfterBlock(block.used, block.target, gasCfg), "actual.AfterBlock()")
 		}
 	})
 }
@@ -366,13 +350,11 @@ func FuzzPriceInvarianceAfterBlock(f *testing.F) {
 		initPrice := tm.Price()
 
 		{
-			hooks := hookstest.NewStub(
-				gas.Gas(newTarget),
-				hookstest.WithGasPriceConfig(saetypes.GasPriceConfig{
-					MinPrice:              gas.Price(newMinPrice),
-					TargetToExcessScaling: gas.Gas(newScaling),
-					StaticPricing:         newStaticPricing,
-				}))
+			cfg := saetypes.GasPriceConfig{
+				MinPrice:              gas.Price(newMinPrice),
+				TargetToExcessScaling: gas.Gas(newScaling),
+				StaticPricing:         newStaticPricing,
+			}
 
 			var wantErrIs error
 			if newScaling == 0 || newMinPrice == 0 {
@@ -382,8 +364,8 @@ func FuzzPriceInvarianceAfterBlock(f *testing.F) {
 			// Consuming gas increases the excess, which changes the price.
 			// We're only interested in invariance under changes in config.
 			const gasUsed = 0
-			err := tm.AfterBlock(gasUsed, hooks, nil)
-			require.ErrorIsf(t, err, wantErrIs, "AfterBlock([%+v])", hooks)
+			err := tm.AfterBlock(gasUsed, gas.Gas(newTarget), cfg)
+			require.ErrorIsf(t, err, wantErrIs, "AfterBlock(%d, [%+v])", newTarget, cfg)
 			if wantErrIs != nil {
 				return
 			}

--- a/gastime/config.go
+++ b/gastime/config.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/ava-labs/avalanchego/vms/components/gas"
 
-	"github.com/ava-labs/strevm/hook"
+	saetypes "github.com/ava-labs/strevm/types"
 )
 
 //go:generate go run github.com/StephenButtolph/canoto/canoto $GOFILE
@@ -24,8 +24,8 @@ type config struct {
 
 var errInvalidGasPriceConfig = errors.New("invalid gas price config")
 
-// newConfig builds and validates an internal config from [hook.GasPriceConfig].
-func newConfig(from hook.GasPriceConfig) (config, error) {
+// newConfig builds and validates an internal config from [saetypes.GasPriceConfig].
+func newConfig(from saetypes.GasPriceConfig) (config, error) {
 	if err := from.Validate(); err != nil {
 		return config{}, fmt.Errorf("%w: %w", errInvalidGasPriceConfig, err)
 	}

--- a/gastime/gastime.go
+++ b/gastime/gastime.go
@@ -62,9 +62,9 @@ func New(at time.Time, target, startingExcess gas.Gas, gasPriceConfig saetypes.G
 }
 
 // SubSecond scales [time.Duration] to reflect the given gas rate.
+// `subSec` MUST be in [0, second).
 func SubSecond(subSec time.Duration, rate gas.Gas) gas.Gas { //nolint:staticcheck // subSec intentionally communicates that the value is < time.Second
-	// [hook.Points.SubSecondBlockTime] is required to return values in
-	// [0,second). The lower bound guarantees that the conversion to unsigned
+	// `subSec` is in [0,second). The lower bound guarantees that the conversion to unsigned
 	// [gas.Gas] is safe while the upper bound guarantees that the mul-div
 	// result can't overflow so we don't have to check the error.
 	g, _, _ := intmath.MulDivCeil(

--- a/gastime/gastime.go
+++ b/gastime/gastime.go
@@ -15,6 +15,7 @@ import (
 	"github.com/ava-labs/strevm/hook"
 	"github.com/ava-labs/strevm/intmath"
 	"github.com/ava-labs/strevm/proxytime"
+	saetypes "github.com/ava-labs/strevm/types"
 )
 
 //go:generate go run github.com/StephenButtolph/canoto/canoto $GOFILE
@@ -44,7 +45,7 @@ type Time struct {
 // New returns a new [Time], derived from a [time.Time]. The consumption of
 // `target` * [TargetToRate] units of [gas.Gas] is equivalent to a tick of 1
 // second.
-func New(at time.Time, target, startingExcess gas.Gas, gasPriceConfig hook.GasPriceConfig) (*Time, error) {
+func New(at time.Time, target, startingExcess gas.Gas, gasPriceConfig saetypes.GasPriceConfig) (*Time, error) {
 	cfg, err := newConfig(gasPriceConfig)
 	if err != nil {
 		return nil, err
@@ -88,9 +89,9 @@ const DefaultTargetToExcessScaling = 87
 // parameter in ACP-176's price calculation.
 const DefaultMinPrice gas.Price = 1
 
-// DefaultGasPriceConfig returns the default [hook.GasPriceConfig] values.
-func DefaultGasPriceConfig() hook.GasPriceConfig {
-	return hook.GasPriceConfig{
+// DefaultGasPriceConfig returns the default [saetypes.GasPriceConfig] values.
+func DefaultGasPriceConfig() saetypes.GasPriceConfig {
+	return saetypes.GasPriceConfig{
 		TargetToExcessScaling: DefaultTargetToExcessScaling,
 		MinPrice:              DefaultMinPrice,
 		StaticPricing:         false,
@@ -138,8 +139,8 @@ func (tm *Time) Excess() gas.Gas {
 }
 
 // Price returns the price of a unit of gas, i.e. the "base fee", determined by
-// [gas.CalculatePrice]. However, when [hook.GasPriceConfig.StaticPricing] is
-// true, Price always returns [hook.GasPriceConfig.MinPrice].
+// [gas.CalculatePrice]. However, when [saetypes.GasPriceConfig.StaticPricing] is
+// true, Price always returns [saetypes.GasPriceConfig.MinPrice].
 func (tm *Time) Price() gas.Price {
 	if tm.config.staticPricing {
 		return tm.config.minPrice

--- a/gastime/gastime.go
+++ b/gastime/gastime.go
@@ -9,10 +9,8 @@ import (
 	"time"
 
 	"github.com/ava-labs/avalanchego/vms/components/gas"
-	"github.com/ava-labs/libevm/core/types"
 	"github.com/holiman/uint256"
 
-	"github.com/ava-labs/strevm/hook"
 	"github.com/ava-labs/strevm/intmath"
 	"github.com/ava-labs/strevm/proxytime"
 	saetypes "github.com/ava-labs/strevm/types"
@@ -63,15 +61,14 @@ func New(at time.Time, target, startingExcess gas.Gas, gasPriceConfig saetypes.G
 	}, nil
 }
 
-// SubSecond scales the value returned by [hook.Points.SubSecondBlockTime] to
-// reflect the given gas rate.
-func SubSecond(hooks hook.Points, hdr *types.Header, rate gas.Gas) gas.Gas {
+// SubSecond scales [time.Duration] to reflect the given gas rate.
+func SubSecond(subSec time.Duration, rate gas.Gas) gas.Gas { //nolint:staticcheck // subSec intentionally communicates that the value is < time.Second
 	// [hook.Points.SubSecondBlockTime] is required to return values in
 	// [0,second). The lower bound guarantees that the conversion to unsigned
 	// [gas.Gas] is safe while the upper bound guarantees that the mul-div
 	// result can't overflow so we don't have to check the error.
 	g, _, _ := intmath.MulDivCeil(
-		gas.Gas(hooks.SubSecondBlockTime(hdr)), //nolint:gosec // See above
+		gas.Gas(subSec), //nolint:gosec // See above
 		rate,
 		gas.Gas(time.Second),
 	)

--- a/gastime/gastime_test.go
+++ b/gastime/gastime_test.go
@@ -16,12 +16,12 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/ava-labs/strevm/hook"
 	"github.com/ava-labs/strevm/intmath"
 	"github.com/ava-labs/strevm/proxytime"
+	saetypes "github.com/ava-labs/strevm/types"
 )
 
-func mustNew(tb testing.TB, at time.Time, target, startingExcess gas.Gas, gasPriceConfig hook.GasPriceConfig) *Time {
+func mustNew(tb testing.TB, at time.Time, target, startingExcess gas.Gas, gasPriceConfig saetypes.GasPriceConfig) *Time {
 	tb.Helper()
 	tm, err := New(at, target, startingExcess, gasPriceConfig)
 	require.NoError(tb, err, "New(%v, %d, %d, %v)", at, target, startingExcess, gasPriceConfig)
@@ -36,7 +36,7 @@ func (tm *Time) cloneViaCanotoRoundTrip(tb testing.TB) *Time {
 }
 
 func TestClone(t *testing.T) {
-	tm := mustNew(t, time.Unix(42, 1), 1e6, 1e5, hook.GasPriceConfig{TargetToExcessScaling: 100, MinPrice: 200})
+	tm := mustNew(t, time.Unix(42, 1), 1e6, 1e5, saetypes.GasPriceConfig{TargetToExcessScaling: 100, MinPrice: 200})
 
 	if diff := cmp.Diff(tm, tm.Clone(), CmpOpt()); diff != "" {
 		t.Errorf("%T.Clone() diff (-want +got):\n%s", tm, diff)

--- a/hook/hook.go
+++ b/hook/hook.go
@@ -57,7 +57,7 @@ type Points interface {
 
 	// GasConfigAfter returns the gas target and configuration that should go
 	// into effect immediately after the provided block.
-	GasConfigAfter(*types.Header) (target gas.Gas, c GasPriceConfig)
+	GasConfigAfter(*types.Header) (target gas.Gas, c saetypes.GasPriceConfig)
 	// SubSecondBlockTime returns the sub-second portion of the block time,
 	// which MUST be non-negative and strictly shorter than a second; i.e. a
 	// value d such that 0 <= d < [time.Second].
@@ -187,40 +187,6 @@ func (o *Op) ApplyTo(stateDB *state.StateDB) error {
 	}
 	for to, amount := range o.Mint {
 		stateDB.AddBalance(to, &amount)
-	}
-	return nil
-}
-
-// GasPriceConfig contains gas-related parameters that can be configured via hooks.
-type GasPriceConfig struct {
-	// TargetToExcessScaling is the ratio between the gas target and the
-	// reciprocal of the excess coefficient used in price calculation
-	// (K variable in ACP-176, where K = TargetToExcessScaling * T).
-	// MUST be non-zero.
-	TargetToExcessScaling gas.Gas
-	// MinPrice is the minimum gas price / base fee (M parameter in ACP-176).
-	// MUST be non-zero.
-	MinPrice gas.Price
-	// StaticPricing is a flag indicating whether the gas price should be static
-	// at the minimum price.
-	StaticPricing bool
-}
-
-var (
-	errTargetToExcessScalingZero = errors.New("targetToExcessScaling must be non-zero")
-	errMinPriceZero              = errors.New("minPrice must be non-zero")
-)
-
-// Validate checks that the GasPriceConfig fields are valid.
-func (c *GasPriceConfig) Validate() error {
-	if c.TargetToExcessScaling == 0 {
-		return errTargetToExcessScalingZero
-	}
-	// TODO (ceyonur): Decide whether we want to allow zero min price exclusive for static pricing,
-	// to support fee-less networks.
-	// https://github.com/ava-labs/strevm/issues/266
-	if c.MinPrice == 0 {
-		return errMinPriceZero
 	}
 	return nil
 }

--- a/hook/hookstest/stub.go
+++ b/hook/hookstest/stub.go
@@ -33,7 +33,7 @@ type Stub struct {
 	Ops                     []Op
 	ExecutionResultsDBFn    func(string) (saetypes.ExecutionResults, error)
 	CanExecuteTransactionFn func(common.Address, *common.Address, libevm.StateReader) error
-	GasPriceConfig          hook.GasPriceConfig
+	GasPriceConfig          saetypes.GasPriceConfig
 }
 
 var _ hook.PointsG[Op] = (*Stub)(nil)
@@ -42,7 +42,7 @@ var _ hook.PointsG[Op] = (*Stub)(nil)
 type HookOption = options.Option[Stub]
 
 // WithGasPriceConfig overrides the default gas config.
-func WithGasPriceConfig(cfg hook.GasPriceConfig) HookOption {
+func WithGasPriceConfig(cfg saetypes.GasPriceConfig) HookOption {
 	return options.Func[Stub](func(s *Stub) {
 		s.GasPriceConfig = cfg
 	})
@@ -74,7 +74,7 @@ func WithExecutionResultsDBFn(fn func(string) (saetypes.ExecutionResults, error)
 func NewStub(target gas.Gas, opts ...HookOption) *Stub {
 	// defaultGasPriceConfig is the same as [gastime.DefaultGasPriceConfig]. It is defined
 	// here to avoid a circular dependency between [gastime] and [hookstest].
-	defaultGasPriceConfig := hook.GasPriceConfig{
+	defaultGasPriceConfig := saetypes.GasPriceConfig{
 		TargetToExcessScaling: 87,
 		MinPrice:              1,
 		StaticPricing:         false,
@@ -178,7 +178,7 @@ func (s *Stub) BlockRebuilderFrom(b *types.Block) (hook.BlockBuilder[Op], error)
 }
 
 // GasConfigAfter ignores its argument and always returns [Stub.Target] and [Stub.GasPriceConfig].
-func (s *Stub) GasConfigAfter(*types.Header) (gas.Gas, hook.GasPriceConfig) {
+func (s *Stub) GasConfigAfter(*types.Header) (gas.Gas, saetypes.GasPriceConfig) {
 	return s.Target, s.GasPriceConfig
 }
 

--- a/hook/hookstest/stub.go
+++ b/hook/hookstest/stub.go
@@ -21,6 +21,7 @@ import (
 	"github.com/ava-labs/libevm/params"
 	"github.com/holiman/uint256"
 
+	"github.com/ava-labs/strevm/gastime"
 	"github.com/ava-labs/strevm/hook"
 	"github.com/ava-labs/strevm/saetest"
 	saetypes "github.com/ava-labs/strevm/types"
@@ -72,16 +73,9 @@ func WithExecutionResultsDBFn(fn func(string) (saetypes.ExecutionResults, error)
 // NewStub returns a stub with defaults applied.
 // It uses [gastime.DefaultGasPriceConfig] unless overridden by [WithGasPriceConfig].
 func NewStub(target gas.Gas, opts ...HookOption) *Stub {
-	// defaultGasPriceConfig is the same as [gastime.DefaultGasPriceConfig]. It is defined
-	// here to avoid a circular dependency between [gastime] and [hookstest].
-	defaultGasPriceConfig := saetypes.GasPriceConfig{
-		TargetToExcessScaling: 87,
-		MinPrice:              1,
-		StaticPricing:         false,
-	}
 	return options.ApplyTo(&Stub{
 		Target:         target,
-		GasPriceConfig: defaultGasPriceConfig,
+		GasPriceConfig: gastime.DefaultGasPriceConfig(),
 	}, opts...)
 }
 

--- a/saexec/execution.go
+++ b/saexec/execution.go
@@ -161,7 +161,7 @@ func Execute(
 	parent := b.ParentBlock()
 
 	gasClock := parent.ExecutedByGasTime().Clone()
-	gasClock.BeforeBlock(hooks, b.Header())
+	gasClock.BeforeBlock(b.Header().Time, hooks.SubSecondBlockTime(b.Header()))
 	perTxClock := gasClock.Time.Clone()
 
 	stateDB, err := sdbo.StateDB(parent.PostExecutionStateRoot())
@@ -253,7 +253,8 @@ func Execute(
 	}
 
 	endTime := time.Now()
-	if err := gasClock.AfterBlock(blockGasConsumed, hooks, b.Header()); err != nil {
+	target, gasCfg := hooks.GasConfigAfter(b.Header())
+	if err := gasClock.AfterBlock(blockGasConsumed, target, gasCfg); err != nil {
 		return nil, fmt.Errorf("after-block gas time update: %w", err)
 	}
 

--- a/types/types.go
+++ b/types/types.go
@@ -9,7 +9,10 @@
 package types
 
 import (
+	"errors"
+
 	"github.com/ava-labs/avalanchego/database"
+	"github.com/ava-labs/avalanchego/vms/components/gas"
 	"github.com/ava-labs/libevm/common"
 	"github.com/ava-labs/libevm/core/types"
 )
@@ -28,4 +31,38 @@ type (
 // collision with `rawdb` keys.
 type ExecutionResults struct {
 	database.HeightIndex
+}
+
+// GasPriceConfig contains gas-related parameters that can be configured via hooks.
+type GasPriceConfig struct {
+	// TargetToExcessScaling is the ratio between the gas target and the
+	// reciprocal of the excess coefficient used in price calculation
+	// (K variable in ACP-176, where K = TargetToExcessScaling * T).
+	// MUST be non-zero.
+	TargetToExcessScaling gas.Gas
+	// MinPrice is the minimum gas price / base fee (M parameter in ACP-176).
+	// MUST be non-zero.
+	MinPrice gas.Price
+	// StaticPricing is a flag indicating whether the gas price should be static
+	// at the minimum price.
+	StaticPricing bool
+}
+
+var (
+	errTargetToExcessScalingZero = errors.New("targetToExcessScaling must be non-zero")
+	errMinPriceZero              = errors.New("minPrice must be non-zero")
+)
+
+// Validate checks that the GasPriceConfig fields are valid.
+func (c *GasPriceConfig) Validate() error {
+	if c.TargetToExcessScaling == 0 {
+		return errTargetToExcessScalingZero
+	}
+	// TODO (ceyonur): Decide whether we want to allow zero min price exclusive for static pricing,
+	// to support fee-less networks.
+	// https://github.com/ava-labs/strevm/issues/266
+	if c.MinPrice == 0 {
+		return errMinPriceZero
+	}
+	return nil
 }

--- a/worstcase/state.go
+++ b/worstcase/state.go
@@ -121,7 +121,7 @@ func (s *State) StartBlock(h *types.Header) error {
 		)
 	}
 
-	s.clock.BeforeBlock(s.hooks, h)
+	s.clock.BeforeBlock(h.Time, s.hooks.SubSecondBlockTime(h))
 	s.blockSize = 0
 
 	s.maxBlockSize = safeMaxBlockSize(s.clock)
@@ -338,7 +338,8 @@ func (s *State) GasUsed() uint64 {
 // resulted in said transaction being included, which is reflected in the
 // indexing of tx-sender balances.
 func (s *State) FinishBlock() (*blocks.WorstCaseBounds, error) {
-	if err := s.clock.AfterBlock(s.blockSize, s.hooks, s.curr); err != nil {
+	target, gasCfg := s.hooks.GasConfigAfter(s.curr)
+	if err := s.clock.AfterBlock(s.blockSize, target, gasCfg); err != nil {
 		return nil, fmt.Errorf("finishing block gas time update: %w", err)
 	}
 	s.qSize += s.blockSize

--- a/worstcase/state_test.go
+++ b/worstcase/state_test.go
@@ -277,7 +277,7 @@ func TestMultipleBlocks(t *testing.T) {
 			Time:       block.time,
 		}
 
-		wantLatestEndTime.BeforeBlock(sut.hooks, header)
+		wantLatestEndTime.BeforeBlock(header.Time, sut.hooks.SubSecondBlockTime(header))
 		require.NoErrorf(t, state.StartBlock(header), "StartBlock(%d)", i)
 		require.Equalf(t, block.wantBaseFee, state.BaseFee(), "base fee after StartBlock(%d)", i)
 		require.Equalf(t, block.wantGasLimit, state.GasLimit(), "gas limit after StartBlock(%d)", i)
@@ -292,7 +292,8 @@ func TestMultipleBlocks(t *testing.T) {
 
 		got, err := state.FinishBlock()
 		require.NoError(t, err, "FinishBlock()")
-		require.NoError(t, wantLatestEndTime.AfterBlock(gas.Gas(state.GasUsed()), sut.hooks, header), "AfterBlock()")
+		target, c := sut.hooks.GasConfigAfter(header)
+		require.NoError(t, wantLatestEndTime.AfterBlock(gas.Gas(state.GasUsed()), target, c), "AfterBlock()")
 
 		want := &blocks.WorstCaseBounds{
 			MaxBaseFee:    block.wantBaseFee,


### PR DESCRIPTION
Removing the hooks imports in gastime makes its implementation more intuitive, and not depend on block headers. The naming may now be somewhat overkill. The motivation is to be able to provide the gastime into `BuildBlock` to add the minimum necessary data for state sync through this hook simply, rather than providing a custom type that takes in:

- Excess
- Seconds
- Fraction