### PR TITLE
test: fix `TestAcceptBlock` flake and remove subsequently dead block GC counter

### DIFF
--- a/blocks/block.go
+++ b/blocks/block.go
@@ -10,7 +10,6 @@ import (
 	"errors"
 	"fmt"
 	"math/big"
-	"runtime"
 	"sync/atomic"
 
 	"github.com/ava-labs/avalanchego/utils/logging"
@@ -37,8 +36,7 @@ type Block struct {
 	// Rationale: the ancestral pointers form a linked list that would prevent
 	// garbage collection if not severed. Once a block is settled there is no
 	// need to inspect its history so we sacrifice the ancestors to the GC
-	// Overlord as a sign of our unwavering fealty. See [InMemoryBlockCount] for
-	// observability.
+	// Overlord as a sign of our unwavering fealty.
 	ancestry atomic.Pointer[ancestry]
 	// Only the genesis block or the last pre-SAE block is synchronous. These
 	// are self-settling by definition so their `ancestry` MUST be nil.
@@ -62,14 +60,6 @@ type Block struct {
 	log logging.Logger
 }
 
-var inMemoryBlockCount atomic.Int64
-
-// InMemoryBlockCount returns the number of blocks created with [New] that are
-// yet to have their GC finalizers run.
-func InMemoryBlockCount() int64 {
-	return inMemoryBlockCount.Load()
-}
-
 // New constructs a new Block.
 //
 // While both the `parent` and `lastSettled` arguments MAY be nil, this will
@@ -83,11 +73,6 @@ func New(eth *types.Block, parent, lastSettled *Block, log logging.Logger) (*Blo
 		executed: make(chan struct{}),
 		settled:  make(chan struct{}),
 	}
-
-	inMemoryBlockCount.Add(1)
-	runtime.AddCleanup(b, func(struct{}) {
-		inMemoryBlockCount.Add(-1)
-	}, struct{}{})
 
 	if err := b.SetAncestors(parent, lastSettled); err != nil {
 		return nil, err

--- a/sae/vm_test.go
+++ b/sae/vm_test.go
@@ -12,7 +12,6 @@ import (
 	"math/rand/v2"
 	"net/http/httptest"
 	"os"
-	"runtime"
 	"sync"
 	"testing"
 	"time"
@@ -29,7 +28,6 @@ import (
 	"github.com/ava-labs/avalanchego/snow/snowtest"
 	"github.com/ava-labs/avalanchego/snow/validators/validatorstest"
 	"github.com/ava-labs/avalanchego/utils/logging"
-	"github.com/ava-labs/avalanchego/utils/set"
 	"github.com/ava-labs/libevm/common"
 	"github.com/ava-labs/libevm/core"
 	"github.com/ava-labs/libevm/core/rawdb"
@@ -797,13 +795,6 @@ func TestSyntacticBlockChecks(t *testing.T) {
 }
 
 func TestAcceptBlock(t *testing.T) {
-	// We use a generous timeout because GC finalizers from previous tests take
-	// a long time to run in resource constrained environments.
-	require.EventuallyWithT(t, func(t *assert.CollectT) {
-		runtime.GC()
-		require.Zero(t, blocks.InMemoryBlockCount(), "initial in-memory block count")
-	}, 5*time.Second, 50*time.Millisecond)
-
 	opt, vmTime := withVMTime(t, time.Unix(saeparams.TauSeconds, 0))
 
 	ctx, sut := newSUT(t, 1, opt)
@@ -823,7 +814,6 @@ func TestAcceptBlock(t *testing.T) {
 		sut.assertBlockHashInvariants(ctx, t)
 
 		lastSettled := b.LastSettled().Height()
-		var wantInMemory set.Set[uint64]
 		for i, bb := range unsettled {
 			switch {
 			case bb == nil: // settled earlier
@@ -833,18 +823,20 @@ func TestAcceptBlock(t *testing.T) {
 
 			default:
 				require.Greater(t, bb.Height(), lastSettled, "height of unsettled block")
-				wantInMemory.Add(
-					bb.Height(),
-					bb.ParentBlock().Height(),
-					bb.LastSettled().Height(),
-				)
 			}
 		}
 
-		assert.EventuallyWithT(t, func(t *assert.CollectT) {
-			runtime.GC()
-			require.Equal(t, int64(wantInMemory.Len()), blocks.InMemoryBlockCount(), "in-memory block count")
-		}, 100*time.Millisecond, time.Millisecond)
+		for _, bb := range unsettled {
+			if bb == nil {
+				continue
+			}
+
+			expect := blocks.Executed
+			if bb.Settled() {
+				expect = blocks.Settled
+			}
+			require.NoError(t, bb.CheckInvariants(expect), "block %d lifecycle invariants", bb.Height())
+		}
 	}
 }
 


### PR DESCRIPTION
Closes ava-labs/avalanchego#5238. 

`sae.TestAcceptBlock` was flaky in CI because it asserted on `blocks.InMemoryBlockCount()`, which was a process global counter that was incremented/decremented when a block was created/destroyed (garbage collected) -- it was not test specific! 

In the failing CI run, the test timed out waiting for that count to reach zero, which means that other tests creating and destroying blocks interfered `TestAcceptBlock` -- so this is purely a CI thing not an SAE bug, and very difficult to reproduce locally. 

I removed the garbage collection testing and the eventually... -- so the test now validates acceptance and settlement by checking the block directly, rather than `blocks.InMemoryBlockCount()`. This was the only use of the 'observability' code, so I deleted it, as it was all dead, but I can restore it if it is desired for something else. 

I think this is more a test of SAE correctness now than how the Go runtime garbage collection works.