### PR TITLE
test(sae): only sync mempool once

### DIFF
--- a/sae/vm_test.go
+++ b/sae/vm_test.go
@@ -95,6 +95,8 @@ type SUT struct {
 	hooks   *hookstest.Stub
 	logger  *saetest.TBLogger
 
+	mempoolLock sync.Mutex // must be held when calling [txpool.TxPool.Sync]
+
 	validators *validatorstest.State
 	sender     *enginetest.Sender
 }
@@ -363,21 +365,28 @@ func (s *SUT) addToMempool(tb testing.TB, txs ...*types.Transaction) {
 
 // syncMempool is a convenience wrapper for calling [txpool.TxPool.Sync], which
 // MUST NOT be done in production.
+// Additionally, [txpool.TxPool.Sync] is NOT safe for concurrent use, so this call
+// holds [SUT.mempoolLock].
 func (s *SUT) syncMempool(tb testing.TB) {
 	tb.Helper()
 	var _ txpool.TxPool // maintain import for [comment] rendering
 	p := s.rawVM.mempool.Pool
+
+	s.mempoolLock.Lock()
+	defer s.mempoolLock.Unlock()
 	require.NoErrorf(tb, p.Sync(), "%T.Sync()", p)
 }
 
-// requireInMempool requires that the transaction with the specified hash is
-// eventually in the mempool. It calls [SUT.syncMempool] before every check.
+// requireInMempool requires that each transaction with the specified hashes are
+// eventually in the mempool. Internally calls [SUT.syncMempool], which holds
+// [SUT.mempoolLock].
 func (s *SUT) requireInMempool(tb testing.TB, txs ...common.Hash) {
 	tb.Helper()
+
+	s.syncMempool(tb)
 	require.EventuallyWithTf(
 		tb,
 		func(c *assert.CollectT) {
-			s.syncMempool(tb)
 			for i, tx := range txs {
 				assert.Truef(c, s.rawVM.mempool.Pool.Has(tx), "tx %d:%v not in mempool", i, tx)
 			}

--- a/txgossip/txgossip_test.go
+++ b/txgossip/txgossip_test.go
@@ -12,6 +12,7 @@ import (
 	"math/rand/v2"
 	"path/filepath"
 	"slices"
+	"sync"
 	"testing"
 	"time"
 
@@ -61,6 +62,8 @@ type SUT struct {
 	chain  *blockstest.ChainBuilder
 	wallet *saetest.Wallet
 	exec   *saexec.Executor
+
+	syncLock sync.Mutex // must be held while calling [txpool.TxPool.Sync]
 }
 
 func newWallet(tb testing.TB, numAccounts uint) *saetest.Wallet {
@@ -69,7 +72,7 @@ func newWallet(tb testing.TB, numAccounts uint) *saetest.Wallet {
 	return saetest.NewUNSAFEWallet(tb, numAccounts, signer)
 }
 
-func newSUT(t *testing.T, numAccounts uint) SUT {
+func newSUT(t *testing.T, numAccounts uint) *SUT {
 	t.Helper()
 	logger := saetest.NewTBLogger(t, logging.Warn)
 
@@ -96,7 +99,7 @@ func newSUT(t *testing.T, numAccounts uint) SUT {
 		assert.NoErrorf(t, pool.Close(), "%T.Close()", pool)
 	})
 
-	return SUT{
+	return &SUT{
 		Set:    set,
 		chain:  chain,
 		wallet: wallet,
@@ -114,6 +117,16 @@ func newTxPool(t *testing.T, bc BlockChain) *txpool.TxPool {
 	p, err := txpool.New(1, bc, subs)
 	require.NoError(t, err, "txpool.New()")
 	return p
+}
+
+// syncTxPool calls [txpool.TxPool.Sync] with [SUT.syncLock] held,
+// since it is not safe for concurrent use.
+func (s *SUT) syncTxPool(t require.TestingT) {
+	s.syncLock.Lock()
+	defer s.syncLock.Unlock()
+
+	p := s.set.pool
+	require.NoErrorf(t, p.Sync(), "%T.Sync()", p)
 }
 
 func TestExecutorIntegration(t *testing.T) {
@@ -140,7 +153,7 @@ func TestExecutorIntegration(t *testing.T) {
 
 	t.Run("Iterate_after_Add", func(t *testing.T) {
 		// Note that calls to [txpool.TxPool.Sync] are only necessary in tests,
-		// and MUST NOT be replicated in production.
+		// and MUST NOT be replicated in production, and is NOT concurrent safe.
 		require.NoErrorf(t, s.Pool.Sync(), "%T.Sync()", s.Pool)
 		require.Lenf(t, slices.Collect(s.Iterate), numTxs, "slices.Collect(%T.Iterate)", s.Set)
 	})
@@ -179,7 +192,7 @@ func TestExecutorIntegration(t *testing.T) {
 
 	assert.EventuallyWithTf(
 		t, func(c *assert.CollectT) {
-			require.NoErrorf(c, s.Pool.Sync(), "%T.Sync()", s.Pool)
+			s.syncTxPool(c)
 			assert.Zerof(c, s.Len(), "%T.Len()", s.Set)
 			assert.Emptyf(c, slices.Collect(s.Iterate), "slices.Collect(%T.Iterate)", s.Set)
 			for _, tx := range txs {
@@ -306,7 +319,7 @@ func TestP2PIntegration(t *testing.T) {
 
 			require.NoErrorf(t, send.Add(txViaGossip), "%T.Add()", send.Set)
 			require.NoErrorf(t, send.SendTx(ctx, txViaRPC.Transaction), "%T.SendTx()", send.Set)
-			require.NoErrorf(t, send.Pool.Sync(), "sender %T.Sync()", send.Pool)
+			send.syncTxPool(t)
 
 			t.Run("confirm_setup", func(t *testing.T) {
 				for _, tx := range bothTxs {
@@ -325,7 +338,7 @@ func TestP2PIntegration(t *testing.T) {
 			assert.EventuallyWithTf(
 				t, func(c *assert.CollectT) {
 					require.NoError(t, gossiper.Gossip(ctx))
-					require.NoError(c, recv.Pool.Sync())
+					recv.syncTxPool(t)
 					// Check for the tx from RPC as this is received regardless
 					// of push or pull semantics.
 					require.True(c, recv.Has(txViaRPC.GossipID()))


### PR DESCRIPTION
Resolves #306. The test logs show:
```
--- FAIL: TestRecoverFromDatabase (57.17s)
    recovery_test.go:72: 
        	Error Trace:	/Users/runner/work/avalanchego/avalanchego/vms/saevm/sae/vm_test.go:376
        	            				/Users/runner/work/avalanchego/avalanchego/vms/saevm/sae/vm_test.go:360
        	            				/Users/runner/work/avalanchego/avalanchego/vms/saevm/sae/vm_test.go:398
        	            				/Users/runner/work/avalanchego/avalanchego/vms/saevm/sae/vm_test.go:419
        	            				/Users/runner/work/avalanchego/avalanchego/vms/saevm/sae/vm_test.go:433
        	            				/Users/runner/work/avalanchego/avalanchego/vms/saevm/sae/vm_test.go:443
        	            				/Users/runner/work/avalanchego/avalanchego/vms/saevm/sae/recovery_test.go:72
        	Error:      	Condition never satisfied
        	Test:       	TestRecoverFromDatabase
        	Messages:   	all of txs [[]] to in mempool
FAIL
```

Notice that the tx set is empty. This means that we aren't actually finishing the callback, since there's nothing to assert. I believe this is caused by concurrent calls to `txpool.TxPool.Sync`, since looking at the worker loop, there's a logical race in boolean updating with concurrent calls. I attempted to verify this by editing `syncMempool` to look like:
```go
func (s *SUT) syncMempool(tb testing.TB) {
	tb.Helper()
	var _ txpool.TxPool // maintain import for [comment] rendering
	p := s.rawVM.mempool.Pool
	var wg sync.WaitGroup
	for range 2 {
		wg.Go(func() {
			require.NoErrorf(tb, p.Sync(), "%T.Sync()", p)
		})
	}
	wg.Wait()
}
```
We get the same error almost deterministically.

The correct fix is to only call `syncMempool` once. It's somewhat difficult to verify that this will certainly fix the flake seen when grafting, but I believe it will. Either way, this is still safe, since even though the txs might not be immediately added to the pool with `eth_sendRawTransaction`, they are available to be added as soon as a reset occurs (which is forced by `txpool.TxPool.Sync`).