### PR TITLE
test: Remove all uses of `txpool.TxPool.Sync()`

### DIFF
--- a/sae/recovery_test.go
+++ b/sae/recovery_test.go
@@ -59,7 +59,7 @@ func TestRecoverFromDatabase(t *testing.T) {
 		final = height > saedb.CommitTrieDBEvery
 
 		if !quick {
-			src.mustAddToMempool(t, src.wallet.SetNonceAndSign(t, 0, &types.LegacyTx{
+			src.sendTxsAndWaitUntilPending(t, src.wallet.SetNonceAndSign(t, 0, &types.LegacyTx{
 				To:       nil,                      // execute `Data` as code for contract "construction"
 				Data:     []byte{byte(vm.INVALID)}, // revert and consume all gas
 				Gas:      params.TxGas + params.CreateGas + params.TxDataNonZeroGasFrontier + rng.Uint64N(2e6),

--- a/sae/recovery_test.go
+++ b/sae/recovery_test.go
@@ -59,7 +59,7 @@ func TestRecoverFromDatabase(t *testing.T) {
 		final = height > saedb.CommitTrieDBEvery
 
 		if !quick {
-			src.mustSendTx(t, src.wallet.SetNonceAndSign(t, 0, &types.LegacyTx{
+			src.mustAddToMempool(t, src.wallet.SetNonceAndSign(t, 0, &types.LegacyTx{
 				To:       nil,                      // execute `Data` as code for contract "construction"
 				Data:     []byte{byte(vm.INVALID)}, // revert and consume all gas
 				Gas:      params.TxGas + params.CreateGas + params.TxDataNonZeroGasFrontier + rng.Uint64N(2e6),
@@ -117,8 +117,7 @@ func TestRecoverFromDatabase(t *testing.T) {
 					{"recovered", sutCtx, sut},
 				} {
 					t.Run(sys.name, func(t *testing.T) {
-						sys.mustSendTx(t, tx)
-						b := sys.runConsensusLoop(t)
+						b := sys.runConsensusLoop(t, tx)
 						require.Len(t, b.Transactions(), 1)
 						require.NoError(t, b.WaitUntilExecuted(sys.ctx))
 					})

--- a/sae/rpc_test.go
+++ b/sae/rpc_test.go
@@ -301,8 +301,8 @@ func TestTxPoolNamespace(t *testing.T) {
 	queuedTx := makeTx(queuedAccount)
 	queuedRPCTx := ethapi.NewRPCPendingTransaction(queuedTx, nil, saetest.ChainConfig())
 
-	sut.mustSendTx(t, queuedTx)
-	sut.mustAddToMempool(t, pendingTx)
+	sut.mustSendTx(t, queuedTx, pendingTx)
+	sut.waitUntilTxsPending(t, pendingTx)
 
 	// TODO: This formatting is copied from libevm, consider exposing it somehow
 	// or removing the dependency on the exact format.
@@ -446,7 +446,7 @@ func TestFilterAPIs(t *testing.T) {
 		GasPrice: big.NewInt(1),
 		Gas:      1e6,
 	})
-	sut.mustAddToMempool(t, tx)
+	sut.sendTxsAndWaitUntilPending(t, tx)
 	sut.testRPC(ctx, t, rpcTest{
 		method:     "eth_getFilterChanges",
 		args:       []any{txFilterID},
@@ -770,7 +770,7 @@ func TestEthPendingTransactions(t *testing.T) {
 		GasFeeCap: big.NewInt(1),
 		Value:     big.NewInt(100),
 	})
-	sut.mustAddToMempool(t, tx)
+	sut.sendTxsAndWaitUntilPending(t, tx)
 
 	// eth_pendingTransactions filters results to only transactions from
 	// accounts configured in the AccountManager, which is always empty.
@@ -925,7 +925,7 @@ func TestGetTransactionCount(t *testing.T) {
 		Gas:       params.TxGas,
 		GasFeeCap: big.NewInt(1),
 	})
-	sut.mustAddToMempool(t, tx)
+	sut.sendTxsAndWaitUntilPending(t, tx)
 
 	sut.testRPC(ctx, t, rpcTest{
 		method: "eth_getTransactionCount",
@@ -1000,7 +1000,7 @@ func TestFillTransaction(t *testing.T) {
 		Gas:       params.TxGas,
 		GasFeeCap: big.NewInt(1),
 	})
-	sut.mustAddToMempool(t, tx)
+	sut.sendTxsAndWaitUntilPending(t, tx)
 
 	sut.testRPC(ctx, t, rpcTest{
 		method: "eth_fillTransaction",
@@ -1022,7 +1022,7 @@ func TestResend(t *testing.T) {
 		Gas:       params.TxGas,
 		GasFeeCap: big.NewInt(1),
 	})
-	sut.mustAddToMempool(t, tx)
+	sut.sendTxsAndWaitUntilPending(t, tx)
 
 	sut.testRPC(ctx, t, rpcTest{
 		method: "eth_resend",
@@ -1204,7 +1204,7 @@ func TestDebugGetRawTransaction(t *testing.T) {
 		Gas:       params.TxGas,
 		GasFeeCap: big.NewInt(1),
 	})
-	sut.mustAddToMempool(t, mempoolTx)
+	sut.sendTxsAndWaitUntilPending(t, mempoolTx)
 
 	mempoolMarshaled, err := mempoolTx.MarshalBinary()
 	require.NoErrorf(t, err, "%T.MarshalBinary()", mempoolTx)

--- a/sae/rpc_test.go
+++ b/sae/rpc_test.go
@@ -301,9 +301,8 @@ func TestTxPoolNamespace(t *testing.T) {
 	queuedTx := makeTx(queuedAccount)
 	queuedRPCTx := ethapi.NewRPCPendingTransaction(queuedTx, nil, saetest.ChainConfig())
 
-	sut.mustSendTx(t, pendingTx)
 	sut.mustSendTx(t, queuedTx)
-	sut.syncMempool(t)
+	sut.mustAddToMempool(t, pendingTx)
 
 	// TODO: This formatting is copied from libevm, consider exposing it somehow
 	// or removing the dependency on the exact format.
@@ -447,7 +446,7 @@ func TestFilterAPIs(t *testing.T) {
 		GasPrice: big.NewInt(1),
 		Gas:      1e6,
 	})
-	sut.mustSendTx(t, tx)
+	sut.mustAddToMempool(t, tx)
 	sut.testRPC(ctx, t, rpcTest{
 		method:     "eth_getFilterChanges",
 		args:       []any{txFilterID},
@@ -771,8 +770,7 @@ func TestEthPendingTransactions(t *testing.T) {
 		GasFeeCap: big.NewInt(1),
 		Value:     big.NewInt(100),
 	})
-	sut.mustSendTx(t, tx)
-	sut.requireInMempool(t, tx.Hash())
+	sut.mustAddToMempool(t, tx)
 
 	// eth_pendingTransactions filters results to only transactions from
 	// accounts configured in the AccountManager, which is always empty.
@@ -927,8 +925,7 @@ func TestGetTransactionCount(t *testing.T) {
 		Gas:       params.TxGas,
 		GasFeeCap: big.NewInt(1),
 	})
-	sut.mustSendTx(t, tx)
-	sut.requireInMempool(t, tx.Hash())
+	sut.mustAddToMempool(t, tx)
 
 	sut.testRPC(ctx, t, rpcTest{
 		method: "eth_getTransactionCount",
@@ -1003,8 +1000,7 @@ func TestFillTransaction(t *testing.T) {
 		Gas:       params.TxGas,
 		GasFeeCap: big.NewInt(1),
 	})
-	sut.mustSendTx(t, tx)
-	sut.requireInMempool(t, tx.Hash())
+	sut.mustAddToMempool(t, tx)
 
 	sut.testRPC(ctx, t, rpcTest{
 		method: "eth_fillTransaction",
@@ -1026,8 +1022,7 @@ func TestResend(t *testing.T) {
 		Gas:       params.TxGas,
 		GasFeeCap: big.NewInt(1),
 	})
-	sut.mustSendTx(t, tx)
-	sut.requireInMempool(t, tx.Hash())
+	sut.mustAddToMempool(t, tx)
 
 	sut.testRPC(ctx, t, rpcTest{
 		method: "eth_resend",
@@ -1209,8 +1204,7 @@ func TestDebugGetRawTransaction(t *testing.T) {
 		Gas:       params.TxGas,
 		GasFeeCap: big.NewInt(1),
 	})
-	sut.mustSendTx(t, mempoolTx)
-	sut.syncMempool(t)
+	sut.mustAddToMempool(t, mempoolTx)
 
 	mempoolMarshaled, err := mempoolTx.MarshalBinary()
 	require.NoErrorf(t, err, "%T.MarshalBinary()", mempoolTx)

--- a/sae/tx_test.go
+++ b/sae/tx_test.go
@@ -38,7 +38,7 @@ func TestTxTypeSupport(t *testing.T) {
 
 	for _, tx := range txs {
 		t.Run(fmt.Sprintf("%T", tx), func(t *testing.T) {
-			sut.mustSendTx(t, sut.wallet.SetNonceAndSign(t, 0, tx))
+			sut.sendTxsAndWaitUntilPending(t, sut.wallet.SetNonceAndSign(t, 0, tx))
 		})
 		if t.Failed() {
 			t.FailNow()

--- a/sae/vm_test.go
+++ b/sae/vm_test.go
@@ -34,7 +34,6 @@ import (
 	"github.com/ava-labs/libevm/core"
 	"github.com/ava-labs/libevm/core/rawdb"
 	"github.com/ava-labs/libevm/core/state"
-	"github.com/ava-labs/libevm/core/txpool"
 	"github.com/ava-labs/libevm/core/txpool/legacypool"
 	"github.com/ava-labs/libevm/core/types"
 	"github.com/ava-labs/libevm/core/vm"
@@ -60,6 +59,7 @@ import (
 	"github.com/ava-labs/strevm/hook/hookstest"
 	saeparams "github.com/ava-labs/strevm/params"
 	"github.com/ava-labs/strevm/saetest"
+	"github.com/ava-labs/strevm/txgossip/txgossiptest"
 	saetypes "github.com/ava-labs/strevm/types"
 )
 
@@ -344,47 +344,24 @@ func (s *SUT) context(tb testing.TB) context.Context {
 	return s.logger.CancelOnError(tb.Context())
 }
 
-func (s *SUT) mustSendTx(tb testing.TB, tx *types.Transaction) {
+// mustSendTx guarantees all transactions are delivered to the mempool, and triggers
+// an asynchronous reorg to move all possible transactions from the source addresses
+// to the pending label.
+func (s *SUT) mustSendTx(tb testing.TB, txs ...*types.Transaction) {
 	tb.Helper()
-	require.NoErrorf(tb, s.Client.SendTransaction(s.context(tb), tx), "%T.SendTransaction([%#x])", s.Client, tx.Hash())
-}
 
-// addToMempool is a convenience wrapper around [SUT.mustSendTx] (per tx) and
-// [SUT.requireInMempool].
-func (s *SUT) addToMempool(tb testing.TB, txs ...*types.Transaction) {
-	tb.Helper()
-	txHashes := make([]common.Hash, len(txs))
-	for i, tx := range txs {
-		s.mustSendTx(tb, tx)
-		txHashes[i] = tx.Hash()
+	ctx := s.context(tb)
+	for _, tx := range txs {
+		require.NoErrorf(tb, s.Client.SendTransaction(ctx, tx), "%T.SendTransaction([%#x])", s.Client, tx.Hash())
 	}
-	s.requireInMempool(tb, txHashes...)
 }
 
-// syncMempool is a convenience wrapper for calling [txpool.TxPool.Sync], which
-// MUST NOT be done in production.
-func (s *SUT) syncMempool(tb testing.TB) {
+// mustAddToMempool sends all transactions to the mempool, and waits for
+// each transaction to be marked as pending.
+func (s *SUT) mustAddToMempool(tb testing.TB, txs ...*types.Transaction) {
 	tb.Helper()
-	var _ txpool.TxPool // maintain import for [comment] rendering
-	p := s.rawVM.mempool.Pool
-	require.NoErrorf(tb, p.Sync(), "%T.Sync()", p)
-}
 
-// requireInMempool requires that the transaction with the specified hash is
-// eventually in the mempool. It calls [SUT.syncMempool] before every check.
-func (s *SUT) requireInMempool(tb testing.TB, txs ...common.Hash) {
-	tb.Helper()
-	require.EventuallyWithTf(
-		tb,
-		func(c *assert.CollectT) {
-			s.syncMempool(tb)
-			for i, tx := range txs {
-				assert.Truef(c, s.rawVM.mempool.Pool.Has(tx), "tx %d:%v not in mempool", i, tx)
-			}
-		},
-		250*time.Millisecond, 25*time.Millisecond,
-		"all of txs [%v] to in mempool", txs,
-	)
+	txgossiptest.MustAddToMempool(tb, s.context(tb), s.rawVM.mempool.Pool, s.mustSendTx, txs...)
 }
 
 // buildAndParseBlock calls [SUT.addToMempool] with the provided transactions,
@@ -396,7 +373,7 @@ func (s *SUT) requireInMempool(tb testing.TB, txs ...common.Hash) {
 // of a [blocks.Block], hence its return as a [snowman.Block].
 func (s *SUT) buildAndParseBlock(tb testing.TB, preference *blocks.Block, txs ...*types.Transaction) snowman.Block {
 	tb.Helper()
-	s.addToMempool(tb, txs...)
+	s.mustAddToMempool(tb, txs...)
 
 	ctx := s.context(tb)
 	require.NoError(tb, s.SetPreference(ctx, preference.ID()), "SetPreference()")
@@ -572,7 +549,7 @@ func TestIntegration(t *testing.T) {
 			GasFeeCap: big.NewInt(1),
 			Value:     transfer.ToBig(),
 		})
-		sut.mustSendTx(t, tx)
+		sut.mustAddToMempool(t, tx)
 	}
 
 	select {
@@ -589,9 +566,6 @@ func TestIntegration(t *testing.T) {
 	for range numTxs + 1 {
 		t.Run("WaitForEvent_with_existing_txs", testWaitForEvent)
 	}
-
-	sut.syncMempool(t) // technically we've only proven 1 tx added, as unlikely as a race is
-	require.Equal(t, numTxs, sut.rawVM.numPendingTxs(), "number of pending txs")
 
 	b := sut.runConsensusLoopOnPreference(t, sut.genesis)
 	assert.Equal(t, sut.genesis.ID(), b.Parent(), "BuildBlock() builds on preference")

--- a/sae/vm_test.go
+++ b/sae/vm_test.go
@@ -344,7 +344,7 @@ func (s *SUT) context(tb testing.TB) context.Context {
 	return s.logger.CancelOnError(tb.Context())
 }
 
-// mustSendTx guarantees all transactions are delivered to the mempool, and triggers
+// mustSendTx guarantees all transactions are delivered to the mempool, which triggers
 // an asynchronous reorg to move all possible transactions from the source addresses
 // to the pending label.
 func (s *SUT) mustSendTx(tb testing.TB, txs ...*types.Transaction) {
@@ -356,15 +356,22 @@ func (s *SUT) mustSendTx(tb testing.TB, txs ...*types.Transaction) {
 	}
 }
 
-// mustAddToMempool sends all transactions to the mempool, and waits for
-// each transaction to be marked as pending.
-func (s *SUT) mustAddToMempool(tb testing.TB, txs ...*types.Transaction) {
+// sendTxsAndWaitUntilPending sends all `txs` to the mempool, and waits for
+// each to be marked as pending.
+func (s *SUT) sendTxsAndWaitUntilPending(tb testing.TB, txs ...*types.Transaction) {
 	tb.Helper()
 
-	txgossiptest.MustAddToMempool(tb, s.context(tb), s.rawVM.mempool.Pool, s.mustSendTx, txs...)
+	s.mustSendTx(tb, txs...)
+	s.waitUntilTxsPending(tb, txs...)
 }
 
-// buildAndParseBlock calls [SUT.mustAddToMempool] with the provided transactions,
+func (s *SUT) waitUntilTxsPending(tb testing.TB, txs ...*types.Transaction) {
+	tb.Helper()
+
+	txgossiptest.WaitUntilPending(tb, s.context(tb), s.rawVM.mempool.Pool, txs...)
+}
+
+// buildAndParseBlock adds all `txs` to the mempool and ensures they are pending,
 // builds a new block and passes its bytes to [VM.ParseBlock], the result of
 // which is returned. This is equivalent to a validator having received valid
 // bytes from a peer, but with no element of consensus performed.
@@ -373,7 +380,7 @@ func (s *SUT) mustAddToMempool(tb testing.TB, txs ...*types.Transaction) {
 // of a [blocks.Block], hence its return as a [snowman.Block].
 func (s *SUT) buildAndParseBlock(tb testing.TB, preference *blocks.Block, txs ...*types.Transaction) snowman.Block {
 	tb.Helper()
-	s.mustAddToMempool(tb, txs...)
+	s.sendTxsAndWaitUntilPending(tb, txs...)
 
 	ctx := s.context(tb)
 	require.NoError(tb, s.SetPreference(ctx, preference.ID()), "SetPreference()")
@@ -549,7 +556,7 @@ func TestIntegration(t *testing.T) {
 			GasFeeCap: big.NewInt(1),
 			Value:     transfer.ToBig(),
 		})
-		sut.mustAddToMempool(t, tx)
+		sut.sendTxsAndWaitUntilPending(t, tx)
 	}
 
 	select {

--- a/sae/vm_test.go
+++ b/sae/vm_test.go
@@ -364,7 +364,7 @@ func (s *SUT) mustAddToMempool(tb testing.TB, txs ...*types.Transaction) {
 	txgossiptest.MustAddToMempool(tb, s.context(tb), s.rawVM.mempool.Pool, s.mustSendTx, txs...)
 }
 
-// buildAndParseBlock calls [SUT.addToMempool] with the provided transactions,
+// buildAndParseBlock calls [SUT.mustAddToMempool] with the provided transactions,
 // builds a new block and passes its bytes to [VM.ParseBlock], the result of
 // which is returned. This is equivalent to a validator having received valid
 // bytes from a peer, but with no element of consensus performed.

--- a/sae/worstcase_test.go
+++ b/sae/worstcase_test.go
@@ -233,7 +233,9 @@ func TestWorstCase(t *testing.T) {
 
 					if err := sut.SendTransaction(ctx, tx); err != nil {
 						sut.wallet.DecrementNonce(t, from)
+						continue
 					}
+					sut.waitUntilTxsPending(t, tx)
 				}
 
 				for accepted := false; !accepted; {

--- a/sae/worstcase_test.go
+++ b/sae/worstcase_test.go
@@ -161,12 +161,13 @@ func TestWorstCase(t *testing.T) {
 				wantUsed: params.TxGas + 8*params.TxDataNonZeroGasEIP2028,
 			},
 		}
+		txs := make([]*types.Transaction, 0, len(precompileTests))
 		for _, tt := range precompileTests {
 			var data []byte
 			if k := tt.keep; k != nil {
 				data = binary.BigEndian.AppendUint64(nil, *k)
 			}
-			sut.mustSendTx(t, sut.wallet.SetNonceAndSign(t, 0, &types.DynamicFeeTx{
+			txs = append(txs, sut.wallet.SetNonceAndSign(t, 0, &types.DynamicFeeTx{
 				To:        &guzzle,
 				GasFeeCap: big.NewInt(1),
 				Gas:       tt.limit,
@@ -174,7 +175,7 @@ func TestWorstCase(t *testing.T) {
 			}))
 		}
 
-		b := sut.runConsensusLoop(t)
+		b := sut.runConsensusLoop(t, txs...)
 		require.NoError(t, b.WaitUntilExecuted(ctx), "%T.WaitUntilExecuted()", b)
 		require.Lenf(t, b.Receipts(), len(precompileTests), "%T.Receipts()", b)
 		for i, r := range b.Receipts() {
@@ -234,7 +235,6 @@ func TestWorstCase(t *testing.T) {
 						sut.wallet.DecrementNonce(t, from)
 					}
 				}
-				sut.syncMempool(t)
 
 				for accepted := false; !accepted; {
 					vmTime.advance(time.Millisecond * time.Duration(rng.IntN(1000*3*saeparams.TauSeconds)))

--- a/txgossip/txgossip_test.go
+++ b/txgossip/txgossip_test.go
@@ -139,12 +139,10 @@ func TestExecutorIntegration(t *testing.T) {
 		}
 	}
 
-	txgossiptest.MustAddToMempool(t, ctx, s.Pool, func(tb testing.TB, txs ...*types.Transaction) {
-		tb.Helper()
-		for _, tx := range txs {
-			require.NoErrorf(tb, s.Add(Transaction{tx}), "%T.Add()", s.set)
-		}
-	}, signedTxs...)
+	for _, tx := range signedTxs {
+		require.NoErrorf(t, s.Add(Transaction{tx}), "%T.Add()", s.set)
+	}
+	txgossiptest.WaitUntilPending(t, ctx, s.Pool, signedTxs...)
 
 	t.Run("Iterate_after_Add", func(t *testing.T) {
 		require.Lenf(t, slices.Collect(s.Iterate), numTxs, "slices.Collect(%T.Iterate)", s.Set)
@@ -310,11 +308,9 @@ func TestP2PIntegration(t *testing.T) {
 				send.RegisterPushGossiper(g)
 			}
 
-			txgossiptest.MustAddToMempool(t, ctx, send.Pool, func(tb testing.TB, _ ...*types.Transaction) {
-				tb.Helper()
-				require.NoErrorf(tb, send.Add(txViaGossip), "%T.Add()", send.Set)
-				require.NoErrorf(tb, send.SendTx(ctx, txViaRPC.Transaction), "%T.SendTx()", send.Set)
-			}, txViaRPC.Transaction, txViaGossip.Transaction)
+			require.NoErrorf(t, send.Add(txViaGossip), "%T.Add()", send.Set)
+			require.NoErrorf(t, send.SendTx(ctx, txViaRPC.Transaction), "%T.SendTx()", send.Set)
+			txgossiptest.WaitUntilPending(t, ctx, send.Pool, txViaRPC.Transaction, txViaGossip.Transaction)
 
 			t.Run("confirm_setup", func(t *testing.T) {
 				for _, tx := range bothTxs {

--- a/txgossip/txgossip_test.go
+++ b/txgossip/txgossip_test.go
@@ -177,12 +177,13 @@ func TestExecutorIntegration(t *testing.T) {
 	require.Lenf(t, txs, numTxs, "%T.TransactionsByPriority()", s.Set)
 	require.Equalf(t, numTxs, s.Len(), "%T.Len()", s.Set)
 
+	b := s.chain.NewBlock(t, txs)
+	require.NoErrorf(t, s.exec.Enqueue(ctx, b), "%T.Enqueue([txs from %T.TransactionsByPriority()])", s.exec, s.Set)
+
 	t.Run("block_execution", func(t *testing.T) {
 		// The above test for nonce ordering only runs if the same sender has 2
 		// consecutive transactions. Successful execution demonstrates correct
 		// nonce ordering across the board.
-		b := s.chain.NewBlock(t, txs)
-		require.NoErrorf(t, s.exec.Enqueue(ctx, b), "%T.Enqueue([txs from %T.TransactionsByPriority()])", s.exec, s.Set)
 
 		require.NoErrorf(t, b.WaitUntilExecuted(ctx), "%T.WaitUntilExecuted()", b)
 

--- a/txgossip/txgossip_test.go
+++ b/txgossip/txgossip_test.go
@@ -42,6 +42,7 @@ import (
 	"github.com/ava-labs/strevm/saedb"
 	"github.com/ava-labs/strevm/saetest"
 	"github.com/ava-labs/strevm/saexec"
+	"github.com/ava-labs/strevm/txgossip/txgossiptest"
 )
 
 func TestMain(m *testing.M) {
@@ -126,22 +127,26 @@ func TestExecutorIntegration(t *testing.T) {
 
 	const txPerAccount = 5
 	const numTxs = numAccounts * txPerAccount
+	signedTxs := make([]*types.Transaction, 0, numTxs)
 	for range txPerAccount {
 		for i := range numAccounts {
-			tx := s.wallet.SetNonceAndSign(t, i, &types.DynamicFeeTx{
+			signedTxs = append(signedTxs, s.wallet.SetNonceAndSign(t, i, &types.DynamicFeeTx{
 				To:        &common.Address{},
 				Gas:       params.TxGas,
 				GasFeeCap: big.NewInt(100),
 				GasTipCap: big.NewInt(1 + rng.Int64N(3)),
-			})
-			require.NoErrorf(t, s.Add(Transaction{tx}), "%T.Add()", s.Set)
+			}))
 		}
 	}
 
+	txgossiptest.MustAddToMempool(t, ctx, s.Pool, func(tb testing.TB, txs ...*types.Transaction) {
+		tb.Helper()
+		for _, tx := range txs {
+			require.NoErrorf(tb, s.Add(Transaction{tx}), "%T.Add()", s.set)
+		}
+	}, signedTxs...)
+
 	t.Run("Iterate_after_Add", func(t *testing.T) {
-		// Note that calls to [txpool.TxPool.Sync] are only necessary in tests,
-		// and MUST NOT be replicated in production.
-		require.NoErrorf(t, s.Pool.Sync(), "%T.Sync()", s.Pool)
 		require.Lenf(t, slices.Collect(s.Iterate), numTxs, "slices.Collect(%T.Iterate)", s.Set)
 	})
 	if t.Failed() {
@@ -174,27 +179,30 @@ func TestExecutorIntegration(t *testing.T) {
 	require.Lenf(t, txs, numTxs, "%T.TransactionsByPriority()", s.Set)
 	require.Equalf(t, numTxs, s.Len(), "%T.Len()", s.Set)
 
-	b := s.chain.NewBlock(t, txs)
-	require.NoErrorf(t, s.exec.Enqueue(ctx, b), "%T.Enqueue([txs from %T.TransactionsByPriority()])", s.exec, s.Set)
-
-	assert.EventuallyWithTf(
-		t, func(c *assert.CollectT) {
-			require.NoErrorf(c, s.Pool.Sync(), "%T.Sync()", s.Pool)
-			assert.Zerof(c, s.Len(), "%T.Len()", s.Set)
-			assert.Emptyf(c, slices.Collect(s.Iterate), "slices.Collect(%T.Iterate)", s.Set)
-			for _, tx := range txs {
-				assert.Falsef(c, s.Has(ids.ID(tx.Hash())), "%T.Has(%#x)", s.Set, tx.Hash())
-			}
-		},
-		2*time.Second, 10*time.Millisecond,
-		"empty %T after transactions included in a block", s.Set,
-	)
-
 	t.Run("block_execution", func(t *testing.T) {
 		// The above test for nonce ordering only runs if the same sender has 2
 		// consecutive transactions. Successful execution demonstrates correct
 		// nonce ordering across the board.
+		b := s.chain.NewBlock(t, txs)
+		require.NoErrorf(t, s.exec.Enqueue(ctx, b), "%T.Enqueue([txs from %T.TransactionsByPriority()])", s.exec, s.Set)
+
 		require.NoErrorf(t, b.WaitUntilExecuted(ctx), "%T.WaitUntilExecuted()", b)
+
+		// After the block is executed, a [core.ChainHeadEvent] triggers a reorg
+		// in the mempool. We can't be explicitly notified when the reorg completes,
+		// so polling is necessary.
+		assert.EventuallyWithTf(
+			t, func(c *assert.CollectT) {
+				assert.Zerof(c, s.Len(), "%T.Len()", s.Set)
+				assert.Emptyf(c, slices.Collect(s.Iterate), "slices.Collect(%T.Iterate)", s.Set)
+				for _, tx := range txs {
+					assert.Falsef(c, s.Has(ids.ID(tx.Hash())), "%T.Has(%#x)", s.Set, tx.Hash())
+				}
+			},
+			2*time.Second, 10*time.Millisecond,
+			"empty %T after transactions included in a block", s.Set,
+		)
+
 		for i, r := range b.Receipts() {
 			assert.Equalf(t, types.ReceiptStatusSuccessful, r.Status, "%T[%d].Status", r, i)
 		}
@@ -202,8 +210,6 @@ func TestExecutorIntegration(t *testing.T) {
 }
 
 func TestP2PIntegration(t *testing.T) {
-	ctx := t.Context()
-
 	w := newWallet(t, 1)
 	txViaGossip := Transaction{w.SetNonceAndSign(t, 0, &types.LegacyTx{
 		To:       &common.Address{},
@@ -264,7 +270,7 @@ func TestP2PIntegration(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			logger := saetest.NewTBLogger(t, logging.Debug)
-			ctx = logger.CancelOnError(ctx)
+			ctx := logger.CancelOnError(t.Context())
 
 			sendID := ids.GenerateTestNodeID()
 			recvID := ids.GenerateTestNodeID()
@@ -304,9 +310,11 @@ func TestP2PIntegration(t *testing.T) {
 				send.RegisterPushGossiper(g)
 			}
 
-			require.NoErrorf(t, send.Add(txViaGossip), "%T.Add()", send.Set)
-			require.NoErrorf(t, send.SendTx(ctx, txViaRPC.Transaction), "%T.SendTx()", send.Set)
-			require.NoErrorf(t, send.Pool.Sync(), "sender %T.Sync()", send.Pool)
+			txgossiptest.MustAddToMempool(t, ctx, send.Pool, func(tb testing.TB, _ ...*types.Transaction) {
+				tb.Helper()
+				require.NoErrorf(tb, send.Add(txViaGossip), "%T.Add()", send.Set)
+				require.NoErrorf(tb, send.SendTx(ctx, txViaRPC.Transaction), "%T.SendTx()", send.Set)
+			}, txViaRPC.Transaction, txViaGossip.Transaction)
 
 			t.Run("confirm_setup", func(t *testing.T) {
 				for _, tx := range bothTxs {
@@ -325,7 +333,6 @@ func TestP2PIntegration(t *testing.T) {
 			assert.EventuallyWithTf(
 				t, func(c *assert.CollectT) {
 					require.NoError(t, gossiper.Gossip(ctx))
-					require.NoError(c, recv.Pool.Sync())
 					// Check for the tx from RPC as this is received regardless
 					// of push or pull semantics.
 					require.True(c, recv.Has(txViaRPC.GossipID()))

--- a/txgossip/txgossip_test.go
+++ b/txgossip/txgossip_test.go
@@ -180,27 +180,26 @@ func TestExecutorIntegration(t *testing.T) {
 	b := s.chain.NewBlock(t, txs)
 	require.NoErrorf(t, s.exec.Enqueue(ctx, b), "%T.Enqueue([txs from %T.TransactionsByPriority()])", s.exec, s.Set)
 
+	// After the block is executed, a [core.ChainHeadEvent] triggers a reorg
+	// in the mempool. We can't be explicitly notified when the reorg completes,
+	// so polling is necessary.
+	assert.EventuallyWithTf(
+		t, func(c *assert.CollectT) {
+			assert.Zerof(c, s.Len(), "%T.Len()", s.Set)
+			assert.Emptyf(c, slices.Collect(s.Iterate), "slices.Collect(%T.Iterate)", s.Set)
+			for _, tx := range txs {
+				assert.Falsef(c, s.Has(ids.ID(tx.Hash())), "%T.Has(%#x)", s.Set, tx.Hash())
+			}
+		},
+		2*time.Second, 10*time.Millisecond,
+		"empty %T after transactions included in a block", s.Set,
+	)
+
 	t.Run("block_execution", func(t *testing.T) {
 		// The above test for nonce ordering only runs if the same sender has 2
 		// consecutive transactions. Successful execution demonstrates correct
 		// nonce ordering across the board.
-
 		require.NoErrorf(t, b.WaitUntilExecuted(ctx), "%T.WaitUntilExecuted()", b)
-
-		// After the block is executed, a [core.ChainHeadEvent] triggers a reorg
-		// in the mempool. We can't be explicitly notified when the reorg completes,
-		// so polling is necessary.
-		assert.EventuallyWithTf(
-			t, func(c *assert.CollectT) {
-				assert.Zerof(c, s.Len(), "%T.Len()", s.Set)
-				assert.Emptyf(c, slices.Collect(s.Iterate), "slices.Collect(%T.Iterate)", s.Set)
-				for _, tx := range txs {
-					assert.Falsef(c, s.Has(ids.ID(tx.Hash())), "%T.Has(%#x)", s.Set, tx.Hash())
-				}
-			},
-			2*time.Second, 10*time.Millisecond,
-			"empty %T after transactions included in a block", s.Set,
-		)
 
 		for i, r := range b.Receipts() {
 			assert.Equalf(t, types.ReceiptStatusSuccessful, r.Status, "%T[%d].Status", r, i)

--- a/txgossip/txgossiptest/mempool.go
+++ b/txgossip/txgossiptest/mempool.go
@@ -13,20 +13,34 @@ import (
 	"github.com/ava-labs/libevm/core/types"
 )
 
-// MustAddToMempool performs `addTx` and waits until `pool` marks all transactions provided as pending.
-func MustAddToMempool(tb testing.TB, ctx context.Context, pool *txpool.TxPool, addTx func(testing.TB, ...*types.Transaction), txs ...*types.Transaction) {
+// WaitUntilPending waits until all transactions provided are marked as pending in `pool`.
+func WaitUntilPending(tb testing.TB, ctx context.Context, pool *txpool.TxPool, txs ...*types.Transaction) {
 	tb.Helper()
 
 	if len(txs) == 0 {
 		return
 	}
 
-	txCh := make(chan core.NewTxsEvent, len(txs))
+	txCh := make(chan core.NewTxsEvent, 1) // size arbitrary
 	sub := pool.SubscribeTransactions(txCh, true /*reorgs but ignored by legacypool*/)
 	defer sub.Unsubscribe()
 
-	addTx(tb, txs...)
 	set := toSet(txs, (*types.Transaction).Hash)
+
+	// Optimistically check current mempool - any reorgs after this will
+	// certainly be caught by the subscription.
+	pendingByAddr, _ := pool.Content()
+	for _, list := range pendingByAddr {
+		for _, tx := range list {
+			delete(set, tx.Hash())
+		}
+	}
+
+	if len(set) == 0 {
+		// already found all txs
+		return
+	}
+
 	for {
 		select {
 		case <-ctx.Done():

--- a/txgossip/txgossiptest/mempool.go
+++ b/txgossip/txgossiptest/mempool.go
@@ -8,6 +8,8 @@ import (
 	"context"
 	"testing"
 
+	"github.com/ava-labs/avalanchego/utils/set"
+	"github.com/ava-labs/libevm/common"
 	"github.com/ava-labs/libevm/core"
 	"github.com/ava-labs/libevm/core/txpool"
 	"github.com/ava-labs/libevm/core/types"
@@ -25,18 +27,21 @@ func WaitUntilPending(tb testing.TB, ctx context.Context, pool *txpool.TxPool, t
 	sub := pool.SubscribeTransactions(txCh, true /*reorgs but ignored by legacypool*/)
 	defer sub.Unsubscribe()
 
-	set := toSet(txs, (*types.Transaction).Hash)
+	s := set.NewSet[common.Hash](len(txs))
+	for _, tx := range txs {
+		s.Add(tx.Hash())
+	}
 
 	// Optimistically check current mempool - any reorgs after this will
 	// certainly be caught by the subscription.
 	pendingByAddr, _ := pool.Content()
 	for _, list := range pendingByAddr {
 		for _, tx := range list {
-			delete(set, tx.Hash())
+			s.Remove(tx.Hash())
 		}
 	}
 
-	if len(set) == 0 {
+	if s.Len() == 0 {
 		// already found all txs
 		return
 	}
@@ -49,20 +54,12 @@ func WaitUntilPending(tb testing.TB, ctx context.Context, pool *txpool.TxPool, t
 			tb.Fatalf("%T.SubscribeTransactions.Err() returned %v", pool, err)
 		case txEvent := <-txCh:
 			for _, tx := range txEvent.Txs {
-				delete(set, tx.Hash())
+				s.Remove(tx.Hash())
 			}
 
-			if len(set) == 0 {
+			if s.Len() == 0 {
 				return
 			}
 		}
 	}
-}
-
-func toSet[T any, I comparable](list []T, indexer func(T) I) map[I]struct{} {
-	m := make(map[I]struct{}, len(list))
-	for _, t := range list {
-		m[indexer(t)] = struct{}{}
-	}
-	return m
 }

--- a/txgossip/txgossiptest/mempool.go
+++ b/txgossip/txgossiptest/mempool.go
@@ -1,0 +1,54 @@
+// Copyright (C) 2025-2026, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE for licensing terms.
+
+// Package txgossiptest provides test helpers for mempool operations.
+package txgossiptest
+
+import (
+	"context"
+	"testing"
+
+	"github.com/ava-labs/libevm/core"
+	"github.com/ava-labs/libevm/core/txpool"
+	"github.com/ava-labs/libevm/core/types"
+)
+
+// MustAddToMempool performs `addTx` and waits until `pool` marks all transactions provided as pending.
+func MustAddToMempool(tb testing.TB, ctx context.Context, pool *txpool.TxPool, addTx func(testing.TB, ...*types.Transaction), txs ...*types.Transaction) {
+	tb.Helper()
+
+	if len(txs) == 0 {
+		return
+	}
+
+	txCh := make(chan core.NewTxsEvent, len(txs))
+	sub := pool.SubscribeTransactions(txCh, true /*reorgs but ignored by legacypool*/)
+	defer sub.Unsubscribe()
+
+	addTx(tb, txs...)
+	set := toSet(txs, (*types.Transaction).Hash)
+	for {
+		select {
+		case <-ctx.Done():
+			tb.Fatalf("%v waiting for %T.SubscribeTransactions()", context.Cause(ctx), pool)
+		case err := <-sub.Err():
+			tb.Fatalf("%T.SubscribeTransactions.Err() returned %v", pool, err)
+		case txEvent := <-txCh:
+			for _, tx := range txEvent.Txs {
+				delete(set, tx.Hash())
+			}
+
+			if len(set) == 0 {
+				return
+			}
+		}
+	}
+}
+
+func toSet[T any, I comparable](list []T, indexer func(T) I) map[I]struct{} {
+	m := make(map[I]struct{}, len(list))
+	for _, t := range list {
+		m[indexer(t)] = struct{}{}
+	}
+	return m
+}


### PR DESCRIPTION
`txpool.TxPool.Sync` is inherently broken, since if there are any pending transactions currently in the mempool, the internal `noncer` isn't accurately recreated. Although we could make a large diff in the legacypool to fix this test-only code, it would be simpler to just wait until the tx is added via a subscription.