### PR TITLE
refactor(params)!: remove Tau as a `time.Duration`

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -21,7 +21,7 @@ jobs:
   # list of the `lint` job as this is what gates PRs.
   lint:
     runs-on: ubuntu-latest
-    needs: [golangci-lint, yamllint, shellcheck, tausecondslint]
+    needs: [golangci-lint, yamllint, shellcheck]
     steps:
       - run: echo "Dependencies successful"
 
@@ -49,15 +49,3 @@ jobs:
       - uses: actions/checkout@v4
       - name: Run ShellCheck
         uses: ludeeus/action-shellcheck@2.0.0
-
-  tausecondslint:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - name: Check for TauSeconds misuse with time.Add()
-        run: |
-          if grep -rn '\.Add([^)]*TauSeconds' --include='*.go' .; then
-            echo "ERROR: Use params.Tau (time.Duration) with time.Add(), not TauSeconds (int)"
-            echo "TauSeconds would be interpreted as nanoseconds, not seconds"
-            exit 1
-          fi

--- a/blocks/settlement_test.go
+++ b/blocks/settlement_test.go
@@ -29,7 +29,8 @@ import (
 //nolint:testableexamples // Output is meaningless
 func ExampleRange() {
 	parent := blockBuildingPreference()
-	settle, ok, err := LastToSettleAt(vmHooks(), time.Now().Add(-params.Tau), parent)
+	timeToSettle := params.Tau * time.Second
+	settle, ok, err := LastToSettleAt(vmHooks(), time.Now().Add(-timeToSettle), parent)
 	if err != nil {
 		// Due to a malformed input to block verification.
 		return // err

--- a/params/params.go
+++ b/params/params.go
@@ -13,14 +13,11 @@ import "time"
 // ceil(g/Lambda).
 const Lambda = 2
 
-// Tau is the minimum duration between a block's execution completing and the
-// resulting state changes being settled in a later block. Note that this period
-// has no effect on the availability nor finality of results, both of which are
-// immediate at the time of executing an individual transaction.
-const (
-	Tau        = TauSeconds * time.Second
-	TauSeconds = 5
-)
+// Tau is the minimum duration in seconds between a block's execution completing
+// and the resulting state changes being settled in a later block. Note that
+// this period has no effect on the availability nor finality of results, both of
+// which are immediate at the time of executing an individual transaction.
+const Tau = 5
 
 // MaxFullBlocksInOpenQueue is the maximum number of full blocks that can be
 // in the execution queue while it remains open to accepting a new block. An
@@ -35,4 +32,4 @@ const MaxFullBlocksInClosedQueue = MaxFullBlocksInOpenQueue + 1
 // MaxQueueWallTime is the maximum wall-clock duration a block should remain in
 // the execution queue before execution finishes. This assumes the executor
 // drains the queue at least as fast as the gas capacity rate R.
-const MaxQueueWallTime = MaxFullBlocksInClosedQueue * Tau * Lambda
+const MaxQueueWallTime = MaxFullBlocksInClosedQueue * Tau * Lambda * time.Second

--- a/sae/block_builder.go
+++ b/sae/block_builder.go
@@ -163,8 +163,8 @@ func (b *blockBuilderG[T]) buildWithTxs(
 	// It is allowed for [hook.BlockBuilder] to further constrain the allowed
 	// block times. However, every block MUST at least satisfy these basic
 	// sanity checks.
-	if bTime.Unix() < saeparams.TauSeconds {
-		return nil, fmt.Errorf("%w: %d < %d", errBlockTimeUnderMinimum, hdr.Time, saeparams.TauSeconds)
+	if bTime.Unix() < saeparams.Tau {
+		return nil, fmt.Errorf("%w: %d < %d", errBlockTimeUnderMinimum, hdr.Time, saeparams.Tau)
 	}
 	if bTime.Compare(pTime) < 0 {
 		return nil, fmt.Errorf("%w: %s < %s", errBlockTimeBeforeParent, bTime.String(), pTime.String())
@@ -175,7 +175,8 @@ func (b *blockBuilderG[T]) buildWithTxs(
 	}
 
 	// Underflow of Add(-tau) is prevented by the above check.
-	lastSettled, ok, err := blocks.LastToSettleAt(b.hooks, bTime.Add(-saeparams.Tau), parent)
+	const timeToSettle = saeparams.Tau * time.Second
+	lastSettled, ok, err := blocks.LastToSettleAt(b.hooks, bTime.Add(-timeToSettle), parent)
 	if err != nil {
 		return nil, err
 	}

--- a/sae/recovery.go
+++ b/sae/recovery.go
@@ -10,7 +10,6 @@ import (
 	"sync/atomic"
 
 	"github.com/ava-labs/avalanchego/utils/logging"
-	"github.com/ava-labs/avalanchego/vms/components/gas"
 	"github.com/ava-labs/libevm/common"
 	"github.com/ava-labs/libevm/core/rawdb"
 	"github.com/ava-labs/libevm/ethdb"
@@ -18,8 +17,6 @@ import (
 
 	"github.com/ava-labs/strevm/blocks"
 	"github.com/ava-labs/strevm/hook"
-	saeparams "github.com/ava-labs/strevm/params"
-	"github.com/ava-labs/strevm/proxytime"
 	"github.com/ava-labs/strevm/saedb"
 	"github.com/ava-labs/strevm/saexec"
 	"github.com/ava-labs/strevm/types"
@@ -120,15 +117,14 @@ func (rec *recovery) consensusCriticalBlocks(exec *saexec.Executor) (_ *syncMap[
 	// extend appends to the chain all the blocks in settler's ancestry up to
 	// and including the block that it settled.
 	extend := func(settler *blocks.Block) error {
-		settleAt := blocks.PreciseTime(rec.hooks, settler.Header()).Add(-saeparams.Tau)
-		tm := proxytime.Of[gas.Gas](settleAt)
+		settledHeight := rec.hooks.SettledHeight(settler.Header())
 
 		for {
 			switch b := lastOf(chain); {
 			case b.Synchronous():
 				return nil
 
-			case b.ExecutedByGasTime().Compare(tm) <= 0:
+			case b.NumberU64() <= settledHeight:
 				if b.Settled() {
 					return nil
 				}

--- a/sae/recovery_test.go
+++ b/sae/recovery_test.go
@@ -35,7 +35,7 @@ import (
 func TestRecoverFromDatabase(t *testing.T) {
 	t.Parallel()
 
-	sutOpt, vmTime := withVMTime(t, time.Unix(saeparams.TauSeconds, 0))
+	sutOpt, vmTime := withVMTime(t, time.Unix(saeparams.Tau, 0))
 
 	var srcDB database.Database
 	srcHDB := saetest.NewHeightIndexDB()
@@ -163,7 +163,7 @@ func TestRecoverSimple(t *testing.T) {
 			var srcDB database.Database
 			srcHDB := saetest.NewHeightIndexDB()
 
-			sutOpt, vmTime := withVMTime(t, time.Unix(saeparams.TauSeconds, 0))
+			sutOpt, vmTime := withVMTime(t, time.Unix(saeparams.Tau, 0))
 			ctx, src := newSUT(t, 1, sutOpt, withExecResultsDB(srcHDB), withCommitInterval(commitInterval), options.Func[sutConfig](func(c *sutConfig) {
 				srcDB = c.db
 				c.logLevel = logging.Warn

--- a/sae/rpc_gasprice_test.go
+++ b/sae/rpc_gasprice_test.go
@@ -86,7 +86,7 @@ func TestFeeHistory(t *testing.T) {
 	require.NoError(t, sut.lastAcceptedBlock(t).WaitUntilExecuted(ctx), "last-accepted Block.WaitUntilExecuted()")
 
 	gasRate := sut.hooks.Target * gastime.TargetToRate
-	blockGasLimit := gasRate * saeparams.TauSeconds * saeparams.Lambda // by definition
+	blockGasLimit := gasRate * saeparams.Tau * saeparams.Lambda // by definition
 	gasUsedRatio := float64(params.TxGas) / float64(blockGasLimit)
 
 	baseFee := hexBig(1)

--- a/sae/rpc_stateful_test.go
+++ b/sae/rpc_stateful_test.go
@@ -199,7 +199,7 @@ func TestDebugTrace(t *testing.T) {
 }
 
 func TestEthCall(t *testing.T) {
-	opt, vmTime := withVMTime(t, time.Unix(saeparams.TauSeconds, 0))
+	opt, vmTime := withVMTime(t, time.Unix(saeparams.Tau, 0))
 	ctx, sut := newSUT(t, 1, opt)
 
 	deploy := &types.LegacyTx{

--- a/sae/rpc_test.go
+++ b/sae/rpc_test.go
@@ -530,7 +530,7 @@ func TestChainID(t *testing.T) {
 }
 
 func TestEthGetters(t *testing.T) {
-	timeOpt, vmTime := withVMTime(t, time.Unix(saeparams.TauSeconds, 0))
+	timeOpt, vmTime := withVMTime(t, time.Unix(saeparams.Tau, 0))
 	blockingPrecompile := common.Address{'b', 'l', 'o', 'c', 'k'}
 	precompileOpt, unblock := withBlockingPrecompile(blockingPrecompile)
 	ctx, sut := newSUT(t, 1, timeOpt, precompileOpt)
@@ -612,7 +612,7 @@ func TestGetLogs(t *testing.T) {
 	// We shorten section size to reduce number of required blocks in the test.
 	const bloomSectionSize = 8
 
-	timeOpt, vmTime := withVMTime(t, time.Unix(saeparams.TauSeconds, 0))
+	timeOpt, vmTime := withVMTime(t, time.Unix(saeparams.Tau, 0))
 	rng := crypto.NewKeccakState()
 	emitter := common.Address{'l', 'o', 'g'}
 	precompile := vm.NewStatefulPrecompile(func(env vm.PrecompileEnvironment, _ []byte) ([]byte, error) {
@@ -790,7 +790,7 @@ func TestGetReceipts(t *testing.T) {
 	// Blocking precompile creates accepted-but-not-executed blocks
 	blockingPrecompile := common.Address{'b', 'l', 'o', 'c', 'k'}
 
-	timeOpt, vmTime := withVMTime(t, time.Unix(saeparams.TauSeconds, 0))
+	timeOpt, vmTime := withVMTime(t, time.Unix(saeparams.Tau, 0))
 	precompileOpt, unblock := withBlockingPrecompile(blockingPrecompile)
 	ctx, sut := newSUT(t, 1, timeOpt, precompileOpt)
 	t.Cleanup(unblock)
@@ -1466,7 +1466,7 @@ func withDebugAPI() sutOption {
 }
 
 func TestResolveBlockNumberOrHash(t *testing.T) {
-	opt, vmTime := withVMTime(t, time.Unix(saeparams.TauSeconds, 0))
+	opt, vmTime := withVMTime(t, time.Unix(saeparams.Tau, 0))
 	ctx, sut := newSUT(t, 0, opt)
 
 	settled := sut.runConsensusLoop(t)

--- a/sae/vm_test.go
+++ b/sae/vm_test.go
@@ -134,7 +134,7 @@ func newSUT(tb testing.TB, numAccounts uint, opts ...sutOption) (context.Context
 		genesis: core.Genesis{
 			Config:     saetest.ChainConfig(),
 			Alloc:      saetest.MaxAllocFor(keys.Addresses()...),
-			Timestamp:  saeparams.TauSeconds,
+			Timestamp:  saeparams.Tau,
 			Difficulty: big.NewInt(0), // irrelevant but required
 		},
 		db: memdb.New(),
@@ -257,7 +257,8 @@ func (t *vmTime) advance(d time.Duration) {
 func (t *vmTime) advanceToSettle(ctx context.Context, tb testing.TB, b *blocks.Block) {
 	tb.Helper()
 	require.NoErrorf(tb, b.WaitUntilExecuted(ctx), "%T.WaitUntilExecuted()", b)
-	to := b.ExecutedByGasTime().AsTime().Add(saeparams.Tau)
+	const timeToSettle = saeparams.Tau * time.Second
+	to := b.ExecutedByGasTime().AsTime().Add(timeToSettle)
 	if t.Before(to) {
 		t.set(to)
 	}
@@ -770,7 +771,7 @@ func TestAcceptBlock(t *testing.T) {
 		require.Zero(t, blocks.InMemoryBlockCount(), "initial in-memory block count")
 	}, 5*time.Second, 50*time.Millisecond)
 
-	opt, vmTime := withVMTime(t, time.Unix(saeparams.TauSeconds, 0))
+	opt, vmTime := withVMTime(t, time.Unix(saeparams.Tau, 0))
 
 	ctx, sut := newSUT(t, 1, opt)
 	// Causes [VM.AcceptBlock] to wait until the block has executed.
@@ -781,7 +782,7 @@ func TestAcceptBlock(t *testing.T) {
 
 	rng := rand.New(rand.NewPCG(0, 0)) //nolint:gosec // Reproducibility is useful for tests
 	for range 100 {
-		ffMillis := 100 + rng.IntN(1000*(1+saeparams.TauSeconds))
+		ffMillis := 100 + rng.IntN(1000*(1+saeparams.Tau))
 		vmTime.advance(time.Millisecond * time.Duration(ffMillis))
 
 		b := sut.runConsensusLoop(t)
@@ -842,7 +843,7 @@ func TestSemanticBlockChecks(t *testing.T) {
 		},
 		{
 			name:    "block_time_under_minimum",
-			time:    saeparams.TauSeconds - 1,
+			time:    saeparams.Tau - 1,
 			wantErr: errBlockTimeUnderMinimum,
 		},
 		{
@@ -933,7 +934,7 @@ func TestGossip(t *testing.T) {
 }
 
 func TestBlockSources(t *testing.T) {
-	opt, vmTime := withVMTime(t, time.Unix(saeparams.TauSeconds, 0))
+	opt, vmTime := withVMTime(t, time.Unix(saeparams.Tau, 0))
 	ctx, sut := newSUT(t, 1, opt)
 
 	genesis := sut.lastAcceptedBlock(t)

--- a/sae/worstcase_test.go
+++ b/sae/worstcase_test.go
@@ -189,7 +189,7 @@ func TestWorstCase(t *testing.T) {
 		t.Run("fuzz", func(t *testing.T) {
 			t.Parallel()
 
-			timeOpt, vmTime := withVMTime(t, time.Unix(saeparams.TauSeconds, 0))
+			timeOpt, vmTime := withVMTime(t, time.Unix(saeparams.Tau, 0))
 
 			ctx, sut := newSUT(t, flags.numAccounts, sutOpt, timeOpt)
 			// If we don't wait for blocks to be executed then their results may
@@ -237,7 +237,7 @@ func TestWorstCase(t *testing.T) {
 				sut.syncMempool(t)
 
 				for accepted := false; !accepted; {
-					vmTime.advance(time.Millisecond * time.Duration(rng.IntN(1000*3*saeparams.TauSeconds)))
+					vmTime.advance(time.Millisecond * time.Duration(rng.IntN(1000*3*saeparams.Tau)))
 
 					require.NoError(t, sut.SetPreference(ctx, sut.lastAcceptedBlock(t).ID()), "SetPreference()")
 

--- a/worstcase/state.go
+++ b/worstcase/state.go
@@ -86,9 +86,7 @@ func NewState(
 	}, nil
 }
 
-const (
-	maxGasSecondsPerBlock = saeparams.TauSeconds * saeparams.Lambda
-)
+const maxGasSecondsPerBlock = saeparams.Tau * saeparams.Lambda
 
 var (
 	errNonConsecutiveBlocks = errors.New("non-consecutive blocks")


### PR DESCRIPTION
The fact that we had `params.Tau` and `params.TauSeconds`, and a specific lint rule to discourage misuse, felt gross. The obvious answer was to remove one of them, which is relatively trivial. The `time.Duration` is only created once for production code anyway.