### PR TITLE
fix: resolve `TestImmediateReceipts` flake

### DIFF
--- a/sae/rpc_receipts_test.go
+++ b/sae/rpc_receipts_test.go
@@ -11,11 +11,12 @@ import (
 	"github.com/ava-labs/libevm/core/types"
 	"github.com/ava-labs/libevm/params"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestImmediateReceipts(t *testing.T) {
 	blocking := common.Address{'b', 'l', 'o', 'c', 'k'}
-	opt, unblock := withBlockingPrecompile(blocking)
+	opt, entered, unblock := withBlockingPrecompile(blocking)
 	ctx, sut := newSUT(t, 1, opt)
 	t.Cleanup(unblock)
 
@@ -44,5 +45,11 @@ func TestImmediateReceipts(t *testing.T) {
 			BlockNumber:       b.Number(),
 		},
 	})
+	// Ensure execution is blocked inside the precompile before asserting.
+	select {
+	case <-entered:
+	case <-ctx.Done():
+		require.NoError(t, ctx.Err(), "context cancelled before precompile was entered")
+	}
 	assert.Falsef(t, b.Executed(), "%T.Executed()", b)
 }

--- a/sae/rpc_stateful_test.go
+++ b/sae/rpc_stateful_test.go
@@ -56,7 +56,7 @@ func TestStateQueryOnNonCanonicalBlock(t *testing.T) {
 // regardless of whether the block is addressed by hash or height.
 func TestStateQueryBlocksUntilExecuted(t *testing.T) {
 	blockingPrecompile := common.Address{'b', 'l', 'o', 'c', 'k'}
-	precompileOpt, unblock := withBlockingPrecompile(blockingPrecompile)
+	precompileOpt, _, unblock := withBlockingPrecompile(blockingPrecompile)
 	ctx, sut := newSUT(t, 2, precompileOpt)
 	defer unblock()
 

--- a/sae/rpc_test.go
+++ b/sae/rpc_test.go
@@ -532,7 +532,7 @@ func TestChainID(t *testing.T) {
 func TestEthGetters(t *testing.T) {
 	timeOpt, vmTime := withVMTime(t, time.Unix(saeparams.TauSeconds, 0))
 	blockingPrecompile := common.Address{'b', 'l', 'o', 'c', 'k'}
-	precompileOpt, unblock := withBlockingPrecompile(blockingPrecompile)
+	precompileOpt, _, unblock := withBlockingPrecompile(blockingPrecompile)
 	ctx, sut := newSUT(t, 1, timeOpt, precompileOpt)
 	t.Cleanup(unblock)
 
@@ -791,7 +791,7 @@ func TestGetReceipts(t *testing.T) {
 	blockingPrecompile := common.Address{'b', 'l', 'o', 'c', 'k'}
 
 	timeOpt, vmTime := withVMTime(t, time.Unix(saeparams.TauSeconds, 0))
-	precompileOpt, unblock := withBlockingPrecompile(blockingPrecompile)
+	precompileOpt, _, unblock := withBlockingPrecompile(blockingPrecompile)
 	ctx, sut := newSUT(t, 1, timeOpt, precompileOpt)
 	t.Cleanup(unblock)
 

--- a/sae/vm_test.go
+++ b/sae/vm_test.go
@@ -302,17 +302,19 @@ func withBloomSectionSize(size uint64) sutOption {
 	})
 }
 
-// withBlockingPrecompile adds a precompile that will block
-// all execution until the releasing function returned is called.
-// This should be called prior to closing the VM to prevent goroutine
-// leaks. The releaser can be called multiple times.
-func withBlockingPrecompile(addr common.Address) (sutOption, func()) {
+// withBlockingPrecompile adds a precompile that blocks until the returned
+// release func is called. The channel closes when the precompile is entered.
+// Call the releaser before VM shutdown to avoid goroutine leaks.
+func withBlockingPrecompile(addr common.Address) (sutOption, <-chan struct{}, func()) {
 	unblock := make(chan struct{})
+	entered := make(chan struct{})
+	enteredOnce := sync.OnceFunc(func() { close(entered) })
 	p := vm.NewStatefulPrecompile(func(vm.PrecompileEnvironment, []byte) ([]byte, error) {
+		enteredOnce()
 		<-unblock
 		return nil, nil
 	})
-	return withPrecompile(addr, p), sync.OnceFunc(func() { close(unblock) })
+	return withPrecompile(addr, p), entered, sync.OnceFunc(func() { close(unblock) })
 }
 
 // withPrecompile adds any precompile at the specified address.


### PR DESCRIPTION
#### Code flow 
- The test builds a block with two txs, a simple transfer (`tx[0]`) and a call to a blocking precompile (`tx[1]`).
- After `Accept()`, the block is enqueued for async execution in a separate goroutine.
- The executor processes txs sequentially. `tx[0]` completes and its receipt is published immediately, then `tx[1]` enters the blocking precompile and waits on a channel.
- The test queries `tx[0]`'s receipt via RPC (which blocks until the receipt is ready), then asserts `b.Executed() == false`, expecting the precompile to still be blocking `tx[1]`.

#### The race condition
- When the RPC call returns, we know `tx[0]`'s receipt is ready, but there's no guarantee the execution goroutine has actually entered the precompile yet. 
- Under CI load, the goroutine could finish both txs before the assertion runs.

#### Proposed fix
- `withBlockingPrecompile` now returns a channel that closes when the precompile is entered.
- The test waits on it before asserting, so `b.Executed() == false` is deterministic.
- Add an `entered` channel to `withBlockingPrecompile` that closes when the precompile starts blocking.
- `TestImmediateReceipts` now waits on this channel before asserting, guaranteeing execution cannot complete.
- Test with `-count=1000` with no failures.

Signed-off-by: Tsvetan Dimitrov (tsvetan.dimitrov@avalabs.org)